### PR TITLE
Reuse players (to circumvent Chrome autoplay issues)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,16 +2,22 @@ import React, { Component } from 'react'
 
 import ReactPlayer from './ReactPlayer'
 
+const DELAY = 5000;
+
 export default class App extends Component {
   state = {
     url: null,
     playing: false,
     volume: 0.8,
     played: 0,
-    loaded: 0
+    loaded: 0,
+    delayLoad: false
   }
   load = url => {
-    this.setState({ url, playing: true })
+    const delay = this.state.delayLoad ? DELAY : 0;
+    setTimeout(() => {
+      this.setState({ url, playing: true })
+    }, delay)
   }
   playPause = () => {
     this.setState({ playing: !this.state.playing })
@@ -51,7 +57,7 @@ export default class App extends Component {
   render () {
     return (
       <div>
-        <h1>rmp</h1>
+        <h1>React Player Test App</h1>
         <ReactPlayer
           ref='player'
           url={this.state.url}
@@ -68,15 +74,6 @@ export default class App extends Component {
         />
         <button onClick={this.stop}>Stop</button>
         <button onClick={this.playPause}>{this.state.playing ? 'Pause' : 'Play'}</button>
-        <button onClick={this.load.bind(this, 'https://www.youtube.com/watch?v=oUFJJNQGwhk')}>Youtube video</button>
-        <button onClick={this.load.bind(this, 'https://soundcloud.com/miami-nights-1984/accelerated')}>Soundcloud song</button>
-        <button onClick={this.load.bind(this, 'https://vimeo.com/90509568')}>Vimeo video</button>
-        <button onClick={this.load.bind(this, 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4')}>MP4 video</button>
-        <button onClick={this.load.bind(this, 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.ogv')}>OGV video</button>
-        <button onClick={this.load.bind(this, 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.webm')}>WEBM video</button>
-        <input ref='url' placeholder='url' />
-        <button onClick={() => { this.load(this.refs.url.value) }}>Load URL</button>
-        <hr />
         seek: <input
           type='range' min={0} max={1} step='any'
           value={this.state.played}
@@ -91,6 +88,22 @@ export default class App extends Component {
           value={this.state.volume}
           onChange={this.setVolume}
         />
+        <hr />
+        <button onClick={this.load.bind(this, 'https://www.youtube.com/watch?v=oUFJJNQGwhk')}>Youtube video</button>
+        <button onClick={this.load.bind(this, 'https://soundcloud.com/miami-nights-1984/accelerated')}>Soundcloud song</button>
+        <button onClick={this.load.bind(this, 'https://vimeo.com/90509568')}>Vimeo video</button>
+        <button onClick={this.load.bind(this, 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4')}>MP4 video</button>
+        <button onClick={this.load.bind(this, 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.ogv')}>OGV video</button>
+        <button onClick={this.load.bind(this, 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.webm')}>WEBM video</button>
+        <input ref='url' placeholder='url' />
+        <button onClick={() => { this.load(this.refs.url.value) }}>Load URL</button>
+        <label>
+          <input
+            type="checkbox"
+            value={this.state.delayLoad}
+            onClick={()=>{this.setState({ delayLoad: !this.state.delayLoad })}}/>
+            <span> delay {DELAY / 1000} seconds</span>
+        </label>
         <hr />
         <textarea ref='config' placeholder='Config JSON' style={{width: '200px', height: '200px'}}></textarea>
         <button onClick={this.onConfigSubmit}>Update Config</button>

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -4,16 +4,18 @@ import 'array.prototype.find'
 import propTypes from './propTypes'
 import players from './players'
 
+const NO_OP = function () {}
+
 export default class ReactPlayer extends Component {
   static propTypes = propTypes
   static defaultProps = {
     volume: 0.8,
     width: 640,
     height: 360,
-    onPlay: function () {}, // TODO: Empty func var in react?
-    onPause: function () {},
-    onBuffer: function () {},
-    onEnded: function () {}
+    onPlay: NO_OP,
+    onPause: NO_OP,
+    onBuffer: NO_OP,
+    onEnded: NO_OP
   }
   static canPlay (url) {
     return players.some(player => player.canPlay(url))
@@ -37,15 +39,29 @@ export default class ReactPlayer extends Component {
       player.seekTo(fraction)
     }
   }
+  renderPlayers () {
+    return players.map(Player => {
+      const canPlay = Player.canPlay(this.props.url);
+      const style = {
+        display: canPlay ? 'block' : 'none'
+      }
+      return (
+        <div style={style}>
+          <Player {...this.props} />
+        </div>
+      )
+    })
+  }
   render () {
     const Player = this.state.Player
     const style = {
       width: this.props.width,
-      height: this.props.height
+      height: this.props.height,
+      background: 'black'
     }
     return (
       <div style={style}>
-        { Player && <Player ref='player' {...this.props} /> }
+        {this.renderPlayers()}
       </div>
     )
   }

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -46,7 +46,7 @@ export default class ReactPlayer extends Component {
         display: canPlay ? 'block' : 'none'
       }
       return (
-        <div style={style}>
+        <div style={style} key={Player.name}>
           <Player ref={canPlay ? "player" : null} {...this.props} />
         </div>
       )

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -47,7 +47,7 @@ export default class ReactPlayer extends Component {
       }
       return (
         <div style={style}>
-          <Player {...this.props} />
+          <Player ref={canPlay ? "player" : null} {...this.props} />
         </div>
       )
     })

--- a/src/players/Base.js
+++ b/src/players/Base.js
@@ -19,9 +19,6 @@ export default class Base extends Component {
   componentWillReceiveProps (nextProps) {
     // Invoke player methods based on incoming props
     const canPlay = this.constructor.canPlay(nextProps.url);
-    this.setState({
-      canPlay
-    });
     if ((this.props.url !== nextProps.url)) {
       if (canPlay) {
         this.play(nextProps.url)
@@ -30,7 +27,7 @@ export default class Base extends Component {
         this.stop()
       }
     } else if ((!this.props.playing && nextProps.playing) && canPlay) {
-      this.play()
+      this.play(nextProps.url)
     } else if ((this.props.playing && !nextProps.playing) && canPlay) {
       this.pause()
     } else if (this.props.volume !== nextProps.volume) {

--- a/src/players/Base.js
+++ b/src/players/Base.js
@@ -10,8 +10,7 @@ export default class Base extends Component {
     onProgress: function () {}
   }
   componentDidMount () {
-    //this.play(this.props.url)
-    //this.update()
+    this.update()
   }
   componentWillUnmount () {
     this.stop()

--- a/src/players/Base.js
+++ b/src/players/Base.js
@@ -10,8 +10,8 @@ export default class Base extends Component {
     onProgress: function () {}
   }
   componentDidMount () {
-    this.play(this.props.url)
-    this.update()
+    //this.play(this.props.url)
+    //this.update()
   }
   componentWillUnmount () {
     this.stop()
@@ -19,12 +19,20 @@ export default class Base extends Component {
   }
   componentWillReceiveProps (nextProps) {
     // Invoke player methods based on incoming props
-    if (this.props.url !== nextProps.url) {
-      this.play(nextProps.url)
-      this.props.onProgress({ played: 0, loaded: 0 })
-    } else if (!this.props.playing && nextProps.playing) {
+    const canPlay = this.constructor.canPlay(nextProps.url);
+    this.setState({
+      canPlay
+    });
+    if ((this.props.url !== nextProps.url)) {
+      if (canPlay) {
+        this.play(nextProps.url)
+        this.props.onProgress({ played: 0, loaded: 0 })
+      } else {
+        this.stop()
+      }
+    } else if ((!this.props.playing && nextProps.playing) && canPlay) {
       this.play()
-    } else if (this.props.playing && !nextProps.playing) {
+    } else if ((this.props.playing && !nextProps.playing) && canPlay) {
       this.pause()
     } else if (this.props.volume !== nextProps.volume) {
       this.setVolume(nextProps.volume)

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -11,6 +11,7 @@ export default class FilePlayer extends Base {
   static canPlay (url) {
     return VIDEO_EXTENSIONS.test(url) || AUDIO_EXTENSIONS.test(url)
   }
+  state = {}
   componentDidMount () {
     this.player = this.refs.player
     this.player.oncanplay = this.onReady
@@ -47,13 +48,14 @@ export default class FilePlayer extends Base {
     return this.player.buffered.end(0) / this.player.duration
   }
   render () {
-    const Media = AUDIO_EXTENSIONS.test(this.props.url) ? 'audio' : 'video'
+    const { url, width, height } = this.props
+    const Media = AUDIO_EXTENSIONS.test(url) ? 'audio' : 'video'
     return (
       <Media
         ref='player'
-        src={this.props.url}
-        width={this.props.width}
-        height={this.props.height}
+        src={url}
+        width={width}
+        height={height}
       />
     )
   }

--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -24,6 +24,7 @@ export default class Vimeo extends Base {
   static canPlay (url) {
     return MATCH_URL.test(url)
   }
+  state = {}
   componentDidMount () {
     window.addEventListener('message', this.onMessage, false)
     this.iframe = this.refs.iframe
@@ -81,12 +82,13 @@ export default class Vimeo extends Base {
     return this.iframe.contentWindow && this.iframe.contentWindow.postMessage(data, this.origin)
   }
   render () {
-    const id = this.props.url.match(MATCH_URL)[3]
+    const { url, vimeoConfig } = this.props
+    const id = ((url || '').match(MATCH_URL) || [])[3]
     const style = {
       width: '100%',
       height: '100%'
     }
-    const iframeParams = { ...DEFAULT_IFRAME_PARAMS, ...this.props.vimeoConfig.iframeParams }
+    const iframeParams = { ...DEFAULT_IFRAME_PARAMS, ...vimeoConfig.iframeParams }
     return (
       <iframe
         ref='iframe'

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -22,6 +22,7 @@ export default class YouTube extends Base {
   static canPlay (url) {
     return MATCH_URL.test(url)
   }
+  state = {}
   shouldComponentUpdate () {
     return false
   }
@@ -43,6 +44,7 @@ export default class YouTube extends Base {
     if (this.player) {
       if (id) {
         this.player.loadVideoById(id)
+        this.player.playVideo()
       } else {
         this.player.playVideo()
       }

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -44,7 +44,6 @@ export default class YouTube extends Base {
     if (this.player) {
       if (id) {
         this.player.loadVideoById(id)
-        this.player.playVideo()
       } else {
         this.player.playVideo()
       }

--- a/test/ReactPlayer.js
+++ b/test/ReactPlayer.js
@@ -24,24 +24,28 @@ describe('ReactPlayer', () => {
   it('renders YouTube player', () => {
     shallowRenderer.render(<ReactPlayer url={YOUTUBE_URL} />)
     const result = shallowRenderer.getRenderOutput()
-    expect(result.props.children.type).to.equal(YouTube)
+    const activePlayer = result.props.children.find(child => child.props.children.ref === 'player')
+    expect(activePlayer.props.children.type).to.equal(YouTube)
   })
 
   it('renders SoundCloud player', () => {
     shallowRenderer.render(<ReactPlayer url={SOUNDCLOUD_URL} />)
     const result = shallowRenderer.getRenderOutput()
-    expect(result.props.children.type).to.equal(SoundCloud)
+    const activePlayer = result.props.children.find(child => child.props.children.ref === 'player')
+    expect(activePlayer.props.children.type).to.equal(SoundCloud)
   })
 
   it('renders Vimeo player', () => {
     shallowRenderer.render(<ReactPlayer url={VIMEO_URL} />)
     const result = shallowRenderer.getRenderOutput()
-    expect(result.props.children.type).to.equal(Vimeo)
+    const activePlayer = result.props.children.find(child => child.props.children.ref === 'player')
+    expect(activePlayer.props.children.type).to.equal(Vimeo)
   })
 
   it('renders FilePlayer', () => {
     shallowRenderer.render(<ReactPlayer url={FILE_URL} />)
     const result = shallowRenderer.getRenderOutput()
-    expect(result.props.children.type).to.equal(FilePlayer)
+    const activePlayer = result.props.children.find(child => child.props.children.ref === 'player')
+    expect(activePlayer.props.children.type).to.equal(FilePlayer)
   })
 })


### PR DESCRIPTION
#### Why

Google Chrome recently implemented a new feature to protect users from tabs that maliciously autoplay audio content. This feature ensures that only tabs/windows that have had focus in the past can autoplay. A side effect of this issue is that the YouTube and Vimeo players (in `react-player`) can no longer autoplay if the tab/window isn't focused, even if that tab/window had focus in the past. This is because `react-player` currently creates and destroys new iframes every time the source url changes. In order to have YouTube and Vimeo play properly while the user is in another tab/window, a change had to be made.

#### What I did

- Changed `react-player` to a render/show system rather than selective rendering. Every player is rendered, but only one player is shown at a time.
- Adjusted logic where necessary to enable the player to work with this new approach
- Updated the tests
- Added a "delay 5 seconds" checkbox to the test page

#### How to verify

- Pull this branch
- `npm run start`
- http://localhost:3000/
- Play a YouTube video
- Play a SoundCloud song
- Check the "delay 5 seconds" checkbox
- Play a YouTube video, then immediately switch to another tab
- After 5 seconds the YouTube player should play, even though the tab is not focused

#### Notes

- Maybe switch to a load & play system. Right now videos/sound are just played right away. Might want to have a "loaded" state where we just do something like [`cueVideoByUrl`](https://developers.google.com/youtube/js_api_reference?hl=en#cueVideoByUrl)
- There might be some dead code that still needs to be sniffed out
- Clean up Vimeo iframe situation