### PR TITLE
Add FilePlayer support for urls with query string

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -2,8 +2,8 @@ import React from 'react'
 
 import Base from './Base'
 
-const VIDEO_EXTENSIONS = /\.(mp4|og[gv]|webm)$/
-const AUDIO_EXTENSIONS = /\.(mp3|wav)$/
+const VIDEO_EXTENSIONS = /\.(mp4|og[gv]|webm)($|\?)/
+const AUDIO_EXTENSIONS = /\.(mp3|wav)($|\?)/
 
 export default class FilePlayer extends Base {
   static displayName = 'FilePlayer';

--- a/test/mocha/canPlay.js
+++ b/test/mocha/canPlay.js
@@ -54,6 +54,12 @@ describe('FilePlayer', () => {
     expect(FilePlayer.canPlay('http://example.com/file.webm')).to.be.true
     expect(FilePlayer.canPlay('http://example.com/file.mp3')).to.be.true
     expect(FilePlayer.canPlay('http://example.com/file.wav')).to.be.true
+    expect(FilePlayer.canPlay('http://example.com/file.mp4?foo=1&bar=2')).to.be.true
+    expect(FilePlayer.canPlay('http://example.com/file.ogg?foo=1&bar=2')).to.be.true
+    expect(FilePlayer.canPlay('http://example.com/file.ogv?foo=1&bar=2')).to.be.true
+    expect(FilePlayer.canPlay('http://example.com/file.webm?foo=1&bar=2')).to.be.true
+    expect(FilePlayer.canPlay('http://example.com/file.mp3?foo=1&bar=2')).to.be.true
+    expect(FilePlayer.canPlay('http://example.com/file.wav?foo=1&bar=2')).to.be.true
   })
 
   it('knows what it can\'t play', () => {


### PR DESCRIPTION
File urls could have a query string. For example: `vk.com` API returns the following urls:

```
https://psv4.vk.me/c611426/u238196536/audios/ccd84e1ca642.mp3?extra=HASH
```