### PR TITLE
Pass on error event

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -16,7 +16,7 @@ export default class FilePlayer extends Base {
     this.player.onplay = this.onPlay
     this.player.onpause = () => this.props.onPause()
     this.player.onended = () => this.props.onEnded()
-    this.player.onerror = () => this.props.onError()
+    this.player.onerror = (e) => this.props.onError(e)
     super.componentDidMount()
   }
   load (url) {


### PR DESCRIPTION
The audio element onerror event was not passed on to the react-player onError method. This PR fixes that. This makes it possible to inspect the actual error: Event > srcElement:audio > error:MediaError > code [1,4]

Error codes can be found here: https://dev.w3.org/html5/spec-preview/media-elements.html#error-codes

This fixes #44 