### PR TITLE
Added media player config for toggling controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ These props allow you to override the parameters for the various players
 
 Prop | Description
 ---- | -----------
+`mediaConfig` | Configuration object for the File player. Set `controls`, to show or hide the controls of the player.
 `soundcloudConfig` | Configuration object for the SoundCloud player. Set `clientId`, to your own SoundCloud app [client ID](https://soundcloud.com/you/apps)
 `vimeoConfig` | Configuration object for the Vimeo player. Set `iframeParams`, to override the [default params](https://developer.vimeo.com/player/embedding#universal-parameters). Set `preload` for [preloading](#preloading)
 `youtubeConfig` | Configuration object for the YouTube player. Set `playerVars`, to override the [default player vars](https://developers.google.com/youtube/player_parameters?playerVersion=HTML5). Set `preload` for [preloading](#preloading)

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -73,7 +73,8 @@ export default class App extends Component {
       played, loaded, duration,
       soundcloudConfig,
       vimeoConfig,
-      youtubeConfig
+      youtubeConfig,
+      mediaConfig
     } = this.state
     const SEPARATOR = ' · '
 
@@ -92,6 +93,7 @@ export default class App extends Component {
             soundcloudConfig={soundcloudConfig}
             vimeoConfig={vimeoConfig}
             youtubeConfig={youtubeConfig}
+            mediaConfig={mediaConfig}
             onPlay={() => this.setState({ playing: true })}
             onPause={() => this.setState({ playing: false })}
             onBuffer={() => console.log('onBuffer')}

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -61,6 +61,7 @@ export default class FilePlayer extends Base {
         width='100%'
         height='100%'
         preload='auto'
+        controls={this.props.mediaConfig.controls}
       />
     )
   }

--- a/src/props.js
+++ b/src/props.js
@@ -19,6 +19,9 @@ export const propTypes = {
     iframeParams: PropTypes.object,
     preload: PropTypes.bool
   }),
+  mediaConfig: PropTypes.shape({
+    controls: PropTypes.bool
+  }),
   onPlay: PropTypes.func,
   onPause: PropTypes.func,
   onBuffer: PropTypes.func,
@@ -34,6 +37,9 @@ export const defaultProps = {
   width: 640,
   height: 360,
   progressFrequency: 1000,
+  mediaConfig: {
+    controls: true
+  },
   soundcloudConfig: {
     clientId: 'e8b6f84fbcad14c301ca1355cae1dea2'
   },


### PR DESCRIPTION
Hi @CookPete. I have added a `mediaConfig` object to the props which consists of a `controls` bool which is used by the `Media` component for the File player to show or hide the controls (shown by default). This request was also made in Issue #11 . Merge this if you consider it a useful feature. Lint didn't give any errors and the tests ran fine.

Best,
Andy