### PR TITLE
SoundCloud to extend FilePlayer (and get rid of sc sdk)

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -5,8 +5,6 @@ import Base from './Base'
 const VIDEO_EXTENSIONS = /\.(mp4|og[gv]|webm)($|\?)/
 const AUDIO_EXTENSIONS = /\.(mp3|wav)($|\?)/
 
-// const AUDIO_EXTENSIONS = /(\.mp3|\.wav|soundcloud.*)($|\?)/
-
 export default class FilePlayer extends Base {
   static displayName = 'FilePlayer'
   static canPlay (url) {

--- a/src/players/SoundCloud.js
+++ b/src/players/SoundCloud.js
@@ -3,7 +3,7 @@
 /* eslint semi: [0] */
 /* eslint max-len: 0 */
 
-import React from 'react'
+// import React from 'react'
 import fetchJSONP from 'fetch-jsonp'
 
 import FilePlayer from './FilePlayer'
@@ -17,12 +17,12 @@ const songData = {} // Cache song data requests
 export default class SoundCloud extends FilePlayer {
 
   static displayName = 'SoundCloud';
-  static canPlay(url) {
+  static canPlay (url) {
     return MATCH_URL.test(url)
   }
 
-  getSongData(url) {
-     if (songData[url]) {
+  getSongData (url) {
+    if (songData[url]) {
       return Promise.resolve(songData[url])
     }
     return fetchJSONP(RESOLVE_URL + '?url=' + url + '&client_id=' + this.props.soundcloudConfig.clientId)
@@ -36,7 +36,7 @@ export default class SoundCloud extends FilePlayer {
       })
   }
 
-  load(url) {
+  load (url) {
     const { clientId } = this.props.soundcloudConfig
     this.stop()
     this.getSongData(url)


### PR DESCRIPTION
Hello, from @CookPete suggestion I finally got somewhere with removing the need for sc sdk and removing most of the code from `SoundCloud`. The test passes (although only in chrome as I still haven't resolved my test env. issue...)

One weird thing is that I can get the sc stream into a `<audio>` but it does not work, and it works like a charm in a `<video>` I'm missing something somewhere...

Anyway not sure if My PR is really helping or if it's more a cry for a free lessons on react and classical inheritance....



Anyway here it is :)
