### PR TITLE
Set playing to true by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import ReactPlayer from 'react-player'
 
 class App extends Component {
   render () {
-    return <ReactPlayer url='https://www.youtube.com/watch?v=ysz5S6PUM-U' playing />
+    return <ReactPlayer url='https://www.youtube.com/watch?v=ysz5S6PUM-U' />
   }
 }
 ```
@@ -72,7 +72,7 @@ Due to various restrictions, `ReactPlayer` is not guaranteed to function properl
 Prop | Description | Default
 ---- | ----------- | -------
 `url` | The url of a video or song to play
-`playing` | Set to `true` or `false` to pause or play the media | `false`
+`playing` | Set to `true` or `false` to pause or play the media | `true`
 `loop` | Set to `true` or `false` to loop the media | `false`
 `controls` | Set to `true` or `false` to display native player controls<br />*Note: Vimeo player controls are not configurable and will always display* | `false`
 `volume` | Sets the volume of the appropriate player | `0.8`

--- a/src/props.js
+++ b/src/props.js
@@ -35,7 +35,7 @@ export const propTypes = {
 }
 
 export const defaultProps = {
-  playing: false,
+  playing: true,
   loop: false,
   controls: false,
   volume: 0.8,

--- a/test/karma/ReactPlayer.js
+++ b/test/karma/ReactPlayer.js
@@ -28,11 +28,11 @@ describe('ReactPlayer', () => {
   })
 
   const testStart = (url, done) => {
-    render(<ReactPlayer url={url} playing onStart={done} />, div)
+    render(<ReactPlayer url={url} onStart={done} />, div)
   }
 
   const testPlay = (url, done) => {
-    render(<ReactPlayer url={url} playing onPlay={done} />, div)
+    render(<ReactPlayer url={url} onPlay={done} />, div)
   }
 
   const testPause = (url, done) => {
@@ -48,11 +48,11 @@ describe('ReactPlayer', () => {
     const onDuration = (duration) => {
       if (duration && duration > 0) done()
     }
-    render(<ReactPlayer url={url} playing onDuration={onDuration} />, div)
+    render(<ReactPlayer url={url} onDuration={onDuration} />, div)
   }
 
   const testError = (url, onError) => {
-    render(<ReactPlayer url={url} playing onError={() => onError()} />, div)
+    render(<ReactPlayer url={url} onError={() => onError()} />, div)
   }
 
   describe('YouTube', () => {
@@ -66,7 +66,7 @@ describe('ReactPlayer', () => {
       const onProgress = (state) => {
         if (state.played > 0.9) done()
       }
-      render(<ReactPlayer url={TEST_YOUTUBE_URL + '?start=22m10s'} playing onProgress={onProgress} />, div)
+      render(<ReactPlayer url={TEST_YOUTUBE_URL + '?start=22m10s'} onProgress={onProgress} />, div)
     })
   })
 


### PR DESCRIPTION
After some thought, I wonder why `playing` isn't `true` by default. Most users, especially those using `ReactPlayer` as a dumb player with no external controls, will want media to be playing if the component has been mounted. This saves a lot of unnecessary `playing={true}` props.

This may be a breaking change and perhaps should wait until `v1.0`, which I think should happen soon.