### PR TITLE
Combine config into single config prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Prop | Description | Default
 `style` | Add [inline styles](https://facebook.github.io/react/tips/inline-styles.html) to the root element
 `progressFrequency` | The time between `onProgress` callbacks, in milliseconds | `1000`
 `playsinline` | Applies the `playsinline` attribute where supported | `false`
+`config` | Override options for the various players, see [config prop](#config-prop)
 
 #### Callback props
 
@@ -103,24 +104,54 @@ Prop | Description
 `onEnded` | Called when media finishes playing
 `onError` | Called when an error occurs whilst attempting to play media
 
-#### Config props
+#### Config prop
 
-These props allow you to override the parameters for the various players:
+As of version `1.0`, there is a single `config` prop to override the settings for the various players. If you are migrating from `0.x`, you must move all the old config props to inside `config`:
 
-Prop | Description
----- | -----------
-`soundcloudConfig` | Configuration object for the SoundCloud player.<br />Set `clientId` to your own SoundCloud app [client ID](https://soundcloud.com/you/apps).<br />Set `showArtwork` to `false` to not load any artwork to display.
-`vimeoConfig` | Configuration object for the Vimeo player.<br />Set `iframeParams` to override the [default params](https://developer.vimeo.com/player/embedding#universal-parameters).<br />Set `preload` for [preloading](#preloading).
-`youtubeConfig` | Configuration object for the YouTube player.<br />Set `playerVars` to override the [default player vars](https://developers.google.com/youtube/player_parameters?playerVersion=HTML5).<br />Set `preload` for [preloading](#preloading).
-`vidmeConfig` | Configuration object for the Vidme player.<br />Set `format` to use a certain quality of video, when available.<br />Possible values: `240p`, `480p`, `720p`, `1080p`, `dash`, `hls`
-`wistiaConfig` | Configuration object for the Wistia player.<br />Set `options` to override the [default player options](https://wistia.com/doc/embed-options#options_list)
-`dailymotionConfig` | Configuration object for the DailyMotion player.<br />Set `params` to override the [default player vars](https://developer.dailymotion.com/player#player-parameters).<br />Set `preload` for [preloading](#preloading).
-`fileConfig` | Configuration object for the file player.<br />Set `attributes` to apply [element attributes](https://developer.mozilla.org/en/docs/Web/HTML/Element/video#Attributes).<br />Set `forceAudio` to always render an `<audio>` element.<br />Set `forceHLS` to use [hls.js](https://github.com/video-dev/hls.js) for HLS streams.<br />Set `forceDASH` to always use [dash.js](https://github.com/Dash-Industry-Forum/dash.js) for DASH streams.
-`facebookConfig` | Configuration object for the Facebook player.<br />Set `appId` to your own [Facebook app ID](https://developers.facebook.com/docs/apps/register#app-id).
+##### Version `0.x`
+
+```js
+<ReactPlayer
+  url={url}
+  youtubeConfig={{ playerVars: { showinfo: 1 } }}
+  facebookConfig={{ appId: '12345' }}
+/>
+```
+
+The old style config props still work but will produce a console warning.
+
+##### Version `1.x`
+
+```js
+<ReactPlayer
+  url={url}
+  config={{
+    youtube: {
+      playerVars: { showinfo: 1 }
+    },
+    facebook: {
+      appId: '12345'
+    }
+  }}
+/>
+```
+
+Settings for each player live under different object keys:
+
+Key | Options
+--- | -------
+`youtube` | Set `playerVars` to override the [default player vars](https://developers.google.com/youtube/player_parameters?playerVersion=HTML5).<br />Set `preload` for [preloading](#preloading).
+`facebook` | Set `appId` to your own [Facebook app ID](https://developers.facebook.com/docs/apps/register#app-id).
+`soundcloud` | Set `clientId` to your own SoundCloud app [client ID](https://soundcloud.com/you/apps).<br />Set `showArtwork` to `false` to not load any artwork to display.
+`vimeo` | Set `iframeParams` to override the [default params](https://developer.vimeo.com/player/embedding#universal-parameters).<br />Set `preload` for [preloading](#preloading).
+`vidme` | Set `format` to use a certain quality of video, when available.<br />Possible values: `240p`, `480p`, `720p`, `1080p`, `dash`, `hls`
+`wistia` | Set `options` to override the [default player options](https://wistia.com/doc/embed-options#options_list)
+`dailymotion` | Set `params` to override the [default player vars](https://developer.dailymotion.com/player#player-parameters).<br />Set `preload` for [preloading](#preloading).
+`file` | Set `attributes` to apply [element attributes](https://developer.mozilla.org/en/docs/Web/HTML/Element/video#Attributes).<br />Set `forceAudio` to always render an `<audio>` element.<br />Set `forceHLS` to use [hls.js](https://github.com/video-dev/hls.js) for HLS streams.<br />Set `forceDASH` to always use [dash.js](https://github.com/Dash-Industry-Forum/dash.js) for DASH streams.
 
 ##### Preloading
 
-Both `youtubeConfig`, `vimeoConfig`, `dailymotionConfig` props can take a `preload` value. Setting this to `true` will play a short, silent video in the background when `ReactPlayer` first mounts. This fixes a [bug](https://github.com/CookPete/react-player/issues/7) where videos would not play when loaded in a background browser tab.
+When `preload` is set to `true` for players that support it, a short, silent video is played in the background when `ReactPlayer` first mounts. This fixes a [bug](https://github.com/CookPete/react-player/issues/7) where videos would not play when loaded in a background browser tab.
 
 #### Multiple Sources and Tracks
 
@@ -148,13 +179,13 @@ You can also specify a `type` for each source by using objects with `src` and `t
 <ReactPlayer
   playing
   url='foo.webm'
-  fileConfig={{
+  config={{ file: {
     tracks: [
       {kind: 'subtitles', src: 'subs/subtitles.en.vtt', srcLang: 'en', default: true},
       {kind: 'subtitles', src: 'subs/subtitles.ja.vtt', srcLang: 'ja'},
       {kind: 'subtitles', src: 'subs/subtitles.de.vtt', srcLang: 'de'}
     ]
-  }}
+  }}}
 />
 ```
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   "dependencies": {
     "fetch-jsonp": "^1.0.2",
     "load-script": "^1.0.0",
+    "lodash.merge": "^4.6.0",
     "lodash.omit": "^4.5.0",
     "prop-types": "^15.5.6"
   },

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react'
 import omit from 'lodash.omit'
 
-import { propTypes, defaultProps } from './props'
+import { propTypes, defaultProps, DEPRECATED_CONFIG_PROPS } from './props'
+import { getConfig } from './utils'
 import YouTube from './players/YouTube'
 import SoundCloud from './players/SoundCloud'
 import Vimeo from './players/Vimeo'
@@ -12,10 +13,24 @@ import Vidme from './players/Vidme'
 import Wistia from './players/Wistia'
 import DailyMotion from './players/DailyMotion'
 
+const SUPPORTED_PROPS = Object.keys(propTypes)
+const SUPPORTED_PLAYERS = [
+  YouTube,
+  SoundCloud,
+  Vimeo,
+  Facebook,
+  FilePlayer,
+  Streamable,
+  Vidme,
+  Wistia,
+  DailyMotion
+]
+
 export default class ReactPlayer extends Component {
   static displayName = 'ReactPlayer'
   static propTypes = propTypes
   static defaultProps = defaultProps
+  config = getConfig(this.props, defaultProps, true)
   componentDidMount () {
     this.progress()
   }
@@ -34,9 +49,8 @@ export default class ReactPlayer extends Component {
     )
   }
   seekTo = fraction => {
-    if (this.player) {
-      this.player.seekTo(fraction)
-    }
+    if (!this.player) return null
+    this.player.seekTo(fraction)
   }
   getDuration = () => {
     if (!this.player) return null
@@ -79,62 +93,46 @@ export default class ReactPlayer extends Component {
   }
   renderPlayers () {
     // Build array of players to render based on URL and preload config
-    const { url, youtubeConfig, vimeoConfig, dailymotionConfig } = this.props
-    const players = []
-    if (YouTube.canPlay(url)) {
-      players.push(YouTube)
-    } else if (SoundCloud.canPlay(url)) {
-      players.push(SoundCloud)
-    } else if (Vimeo.canPlay(url)) {
-      players.push(Vimeo)
-    } else if (Facebook.canPlay(url)) {
-      players.push(Facebook)
-    } else if (DailyMotion.canPlay(url)) {
-      players.push(DailyMotion)
-    } else if (Streamable.canPlay(url)) {
-      players.push(Streamable)
-    } else if (Vidme.canPlay(url)) {
-      players.push(Vidme)
-    } else if (Wistia.canPlay(url)) {
-      players.push(Wistia)
-    } else if (url) {
-      // Fall back to FilePlayer if nothing else can play the URL
-      players.push(FilePlayer)
+    const { url } = this.props
+    const renderPlayers = []
+    for (let Player of SUPPORTED_PLAYERS) {
+      if (Player.canPlay(url)) {
+        renderPlayers.push(Player)
+      }
+    }
+    // Fall back to FilePlayer if nothing else can play the URL
+    if (renderPlayers.length === 0) {
+      renderPlayers.push(FilePlayer)
     }
     // Render additional players if preload config is set
-    if (!YouTube.canPlay(url) && youtubeConfig.preload) {
-      players.push(YouTube)
+    if (!YouTube.canPlay(url) && this.config.youtube.preload) {
+      renderPlayers.push(YouTube)
     }
-    if (!Vimeo.canPlay(url) && vimeoConfig.preload) {
-      players.push(Vimeo)
+    if (!Vimeo.canPlay(url) && this.config.vimeo.preload) {
+      renderPlayers.push(Vimeo)
     }
-    if (!DailyMotion.canPlay(url) && dailymotionConfig.preload) {
-      players.push(DailyMotion)
+    if (!DailyMotion.canPlay(url) && this.config.dailymotion.preload) {
+      renderPlayers.push(DailyMotion)
     }
-    return players.map(this.renderPlayer)
+    return renderPlayers.map(this.renderPlayer)
   }
   ref = player => {
     this.player = player
   }
   renderPlayer = Player => {
     const active = Player.canPlay(this.props.url)
-    const { youtubeConfig, vimeoConfig, dailymotionConfig, ...activeProps } = this.props
-    const props = active ? { ...activeProps, ref: this.ref } : {}
-    // Only youtube and vimeo config passed to
-    // inactive players due to preload behaviour
+    const props = active ? { ...this.props, ref: this.ref } : {}
     return (
       <Player
-        key={Player.displayName}
-        youtubeConfig={youtubeConfig}
-        vimeoConfig={vimeoConfig}
-        dailymotionConfig={dailymotionConfig}
         {...props}
+        key={Player.displayName}
+        config={this.config}
       />
     )
   }
   render () {
     const { style, width, height } = this.props
-    const otherProps = omit(this.props, Object.keys(propTypes))
+    const otherProps = omit(this.props, SUPPORTED_PROPS, DEPRECATED_CONFIG_PROPS)
     const players = this.renderPlayers()
     return (
       <div style={{ ...style, width, height }} {...otherProps}>

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -44,7 +44,6 @@ export default class App extends Component {
     this.setState({ volume: parseFloat(e.target.value) })
   }
   setPlaybackRate = e => {
-    console.log(parseFloat(e.target.value))
     this.setState({ playbackRate: parseFloat(e.target.value) })
   }
   onSeekMouseDown = e => {

--- a/src/players/DailyMotion.js
+++ b/src/players/DailyMotion.js
@@ -9,11 +9,6 @@ const SDK_GLOBAL = 'DM'
 const SDK_GLOBAL_READY = 'dmAsyncInit'
 const MATCH_URL = /^.+dailymotion.com\/(video|hub)\/([^_]+)[^#]*(#video=([^_&]+))?/
 const BLANK_VIDEO_URL = 'http://www.dailymotion.com/video/x522udb'
-const DEFAULT_PLAYER_VARS = {
-  autoplay: 0,
-  api: 1,
-  'endscreen-enable': false
-}
 
 export default class DailyMotion extends Base {
   static displayName = 'DailyMotion'
@@ -21,8 +16,8 @@ export default class DailyMotion extends Base {
     return MATCH_URL.test(url)
   }
   componentDidMount () {
-    const { url, dailymotionConfig } = this.props
-    if (!url && dailymotionConfig.preload) {
+    const { url, config } = this.props
+    if (!url && config.dailymotion.preload) {
       this.preloading = true
       this.load(BLANK_VIDEO_URL)
     }
@@ -50,7 +45,7 @@ export default class DailyMotion extends Base {
     return m[4] || m[2]
   }
   load (url) {
-    const { controls, dailymotionConfig, onError, playing } = this.props
+    const { controls, config, onError, playing } = this.props
     const id = this.parseId(url)
     if (this.player) {
       this.player.load(id, {
@@ -71,12 +66,11 @@ export default class DailyMotion extends Base {
         height: '100%',
         video: id,
         params: {
-          ...DEFAULT_PLAYER_VARS,
           controls: controls,
           autoplay: this.props.playing,
           start: parseStartTime(url),
           origin: window.location.origin,
-          ...dailymotionConfig.params
+          ...config.dailymotion.params
         },
         events: {
           apiready: () => {

--- a/src/players/Facebook.js
+++ b/src/players/Facebook.js
@@ -37,7 +37,7 @@ export default class YouTube extends Base {
     }
     this.getSDK().then(FB => {
       FB.init({
-        appId: this.props.facebookConfig.appId,
+        appId: this.props.config.facebook.appId,
         xfbml: true,
         version: 'v2.5'
       })

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -43,10 +43,10 @@ export default class FilePlayer extends Base {
     super.componentWillUnmount()
   }
   shouldUseHLS (url) {
-    return HLS_EXTENSIONS.test(url) || this.props.fileConfig.forceHLS
+    return HLS_EXTENSIONS.test(url) || this.props.config.file.forceHLS
   }
   shouldUseDASH (url) {
-    return DASH_EXTENSIONS.test(url) || this.props.fileConfig.forceDASH
+    return DASH_EXTENSIONS.test(url) || this.props.config.file.forceDASH
   }
   load (url) {
     if (this.shouldUseHLS(url)) {
@@ -111,8 +111,8 @@ export default class FilePlayer extends Base {
     this.player = player
   }
   render () {
-    const { url, loop, controls, fileConfig, width, height } = this.props
-    const useAudio = AUDIO_EXTENSIONS.test(url) || fileConfig.forceAudio
+    const { url, loop, controls, config, width, height } = this.props
+    const useAudio = AUDIO_EXTENSIONS.test(url) || config.file.forceAudio
     const useHLS = this.shouldUseHLS(url)
     const useDASH = this.shouldUseDASH(url)
     const Element = useAudio ? 'audio' : 'video'
@@ -130,13 +130,11 @@ export default class FilePlayer extends Base {
         preload='auto'
         controls={controls}
         loop={loop}
-        {...fileConfig.attributes}>
+        {...config.file.attributes}>
         {url instanceof Array &&
           url.map(this.renderSource)
         }
-        {fileConfig.tracks instanceof Array &&
-          fileConfig.tracks.map(this.renderTrack)
-        }
+        {config.file.tracks.map(this.renderTrack)}
       </Element>
     )
   }

--- a/src/players/SoundCloud.js
+++ b/src/players/SoundCloud.js
@@ -17,7 +17,6 @@ export default class SoundCloud extends FilePlayer {
   state = {
     image: null
   }
-  clientId = this.props.soundcloudConfig.clientId || defaultProps.soundcloudConfig.clientId
   shouldComponentUpdate (nextProps, nextState) {
     return (
       super.shouldComponentUpdate(nextProps, nextState) ||
@@ -25,10 +24,11 @@ export default class SoundCloud extends FilePlayer {
     )
   }
   getSongData (url) {
+    const { config } = this.props
     if (songData[url]) {
       return Promise.resolve(songData[url])
     }
-    return fetchJSONP(RESOLVE_URL + '?url=' + url + '&client_id=' + this.clientId)
+    return fetchJSONP(RESOLVE_URL + '?url=' + url + '&client_id=' + config.soundcloud.clientId)
       .then(response => {
         if (response.ok) {
           songData[url] = response.json()
@@ -39,7 +39,7 @@ export default class SoundCloud extends FilePlayer {
       })
   }
   load (url) {
-    const { soundcloudConfig, onError } = this.props
+    const { config, onError } = this.props
     this.stop()
     this.getSongData(url).then(data => {
       if (!this.mounted) return
@@ -48,10 +48,10 @@ export default class SoundCloud extends FilePlayer {
         return
       }
       const image = data.artwork_url || data.user.avatar_url
-      if (image && soundcloudConfig.showArtwork) {
+      if (image && config.soundcloud.showArtwork) {
         this.setState({ image: image.replace('-large', '-t500x500') })
       }
-      this.player.src = data.stream_url + '?client_id=' + this.clientId
+      this.player.src = data.stream_url + '?client_id=' + config.soundcloud.clientId
     }, onError)
   }
   ref = player => {

--- a/src/players/Vidme.js
+++ b/src/players/Vidme.js
@@ -27,13 +27,13 @@ export default class Vidme extends FilePlayer {
       })
   }
   getURL ({ video }) {
-    const { vidmeConfig } = this.props
-    if (vidmeConfig.format && video.formats && video.formats.length !== 0) {
-      const index = video.formats.findIndex(f => f.type === vidmeConfig.format)
+    const { config } = this.props
+    if (config.vidme.format && video.formats && video.formats.length !== 0) {
+      const index = video.formats.findIndex(f => f.type === config.vidme.format)
       if (index !== -1) {
         return video.formats[index].uri
       } else {
-        console.warn(`Vidme format "${vidmeConfig.format}" was not found for ${video.full_url}`)
+        console.warn(`Vidme format "${config.vidme.format}" was not found for ${video.full_url}`)
       }
     }
     return video.complete_url

--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -8,22 +8,14 @@ const SDK_GLOBAL = 'Vimeo'
 const MATCH_URL = /https?:\/\/(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|album\/(\d+)\/video\/|video\/|)(\d+)(?:$|\/|\?)/
 const BLANK_VIDEO_URL = 'https://vimeo.com/127250231'
 
-const DEFAULT_OPTIONS = {
-  autopause: false,
-  autoplay: false,
-  byline: false,
-  portrait: false,
-  title: false
-}
-
 export default class Vimeo extends Base {
   static displayName = 'Vimeo'
   static canPlay (url) {
     return MATCH_URL.test(url)
   }
   componentDidMount () {
-    const { url, vimeoConfig } = this.props
-    if (!url && vimeoConfig.preload) {
+    const { url, config } = this.props
+    if (!url && config.vimeo.preload) {
       this.preloading = true
       this.load(BLANK_VIDEO_URL)
     }
@@ -54,8 +46,7 @@ export default class Vimeo extends Base {
     this.loadingSDK = true
     this.getSDK().then(Vimeo => {
       this.player = new Vimeo.Player(this.container, {
-        ...DEFAULT_OPTIONS,
-        ...this.props.vimeoConfig.playerOptions,
+        ...this.props.config.vimeo.playerOptions,
         url,
         loop: this.props.loop
       })

--- a/src/players/Wistia.js
+++ b/src/players/Wistia.js
@@ -13,13 +13,13 @@ export default class Wistia extends Base {
     return MATCH_URL.test(url)
   }
   componentDidMount () {
-    const { onStart, onPause, onEnded, wistiaConfig } = this.props
+    const { onStart, onPause, onEnded, config } = this.props
     this.loadingSDK = true
     this.getSDK().then(() => {
       window._wq = window._wq || []
       window._wq.push({
         id: this.getID(this.props.url),
-        options: wistiaConfig.options,
+        options: config.wistia.options,
         onReady: player => {
           this.player = player
           this.player.bind('start', onStart)

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -9,13 +9,6 @@ const SDK_GLOBAL = 'YT'
 const SDK_GLOBAL_READY = 'onYouTubeIframeAPIReady'
 const MATCH_URL = /^(?:https?:\/\/)?(?:www\.|m\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
 const BLANK_VIDEO_URL = 'https://www.youtube.com/watch?v=GlCmAC4MHek'
-const DEFAULT_PLAYER_VARS = {
-  autoplay: 0,
-  playsinline: 1,
-  showinfo: 0,
-  rel: 0,
-  iv_load_policy: 3
-}
 
 export default class YouTube extends Base {
   static displayName = 'YouTube'
@@ -23,8 +16,8 @@ export default class YouTube extends Base {
     return MATCH_URL.test(url)
   }
   componentDidMount () {
-    const { url, youtubeConfig } = this.props
-    if (!url && youtubeConfig.preload) {
+    const { url, config } = this.props
+    if (!url && config.youtube.preload) {
       this.preloading = true
       this.load(BLANK_VIDEO_URL)
     }
@@ -46,7 +39,7 @@ export default class YouTube extends Base {
     })
   }
   load (url) {
-    const { playsinline, controls, youtubeConfig, onError } = this.props
+    const { playsinline, controls, config, onError } = this.props
     const id = url && url.match(MATCH_URL)[1]
     if (this.isReady) {
       this.player.cueVideoById({
@@ -66,12 +59,11 @@ export default class YouTube extends Base {
         height: '100%',
         videoId: id,
         playerVars: {
-          ...DEFAULT_PLAYER_VARS,
           controls: controls ? 1 : 0,
           start: parseStartTime(url),
           origin: window.location.origin,
           playsinline: playsinline,
-          ...youtubeConfig.playerVars
+          ...config.youtube.playerVars
         },
         events: {
           onReady: this.onReady,

--- a/src/props.js
+++ b/src/props.js
@@ -14,37 +14,39 @@ export const propTypes = {
   style: object,
   progressFrequency: number,
   playsinline: bool,
-  soundcloudConfig: shape({
-    clientId: string,
-    showArtwork: bool
-  }),
-  youtubeConfig: shape({
-    playerVars: object,
-    preload: bool
-  }),
-  facebookConfig: shape({
-    appId: string
-  }),
-  dailymotionConfig: shape({
-    params: object,
-    preload: bool
-  }),
-  vimeoConfig: shape({
-    iframeParams: object,
-    preload: bool
-  }),
-  vidmeConfig: shape({
-    format: string
-  }),
-  fileConfig: shape({
-    attributes: object,
-    tracks: array,
-    forceAudio: bool,
-    forceHLS: bool,
-    forceDASH: bool
-  }),
-  wistiaConfig: shape({
-    options: object
+  config: shape({
+    soundcloud: shape({
+      clientId: string,
+      showArtwork: bool
+    }),
+    youtube: shape({
+      playerVars: object,
+      preload: bool
+    }),
+    facebook: shape({
+      appId: string
+    }),
+    dailymotion: shape({
+      params: object,
+      preload: bool
+    }),
+    vimeo: shape({
+      iframeParams: object,
+      preload: bool
+    }),
+    vidme: shape({
+      format: string
+    }),
+    file: shape({
+      attributes: object,
+      tracks: array,
+      forceAudio: bool,
+      forceHLS: bool,
+      forceDASH: bool
+    }),
+    wistia: shape({
+      options: object
+    })
   }),
   onReady: func,
   onStart: func,
@@ -68,37 +70,55 @@ export const defaultProps = {
   hidden: false,
   progressFrequency: 1000,
   playsinline: false,
-  soundcloudConfig: {
-    clientId: 'e8b6f84fbcad14c301ca1355cae1dea2',
-    showArtwork: true
-  },
-  youtubeConfig: {
-    playerVars: {},
-    preload: false
-  },
-  facebookConfig: {
-    appId: '1309697205772819'
-  },
-  dailymotionConfig: {
-    params: {},
-    preload: false
-  },
-  vimeoConfig: {
-    iframeParams: {},
-    preload: false
-  },
-  vidmeConfig: {
-    format: null
-  },
-  fileConfig: {
-    attributes: {},
-    tracks: [],
-    forceAudio: false,
-    forceHLS: false,
-    forceDASH: false
-  },
-  wistiaConfig: {
-    options: {}
+  config: {
+    soundcloud: {
+      clientId: 'e8b6f84fbcad14c301ca1355cae1dea2',
+      showArtwork: true
+    },
+    youtube: {
+      playerVars: {
+        autoplay: 0,
+        playsinline: 1,
+        showinfo: 0,
+        rel: 0,
+        iv_load_policy: 3
+      },
+      preload: false
+    },
+    facebook: {
+      appId: '1309697205772819'
+    },
+    dailymotion: {
+      params: {
+        autoplay: 0,
+        api: 1,
+        'endscreen-enable': false
+      },
+      preload: false
+    },
+    vimeo: {
+      playerOptions: {
+        autopause: false,
+        autoplay: false,
+        byline: false,
+        portrait: false,
+        title: false
+      },
+      preload: false
+    },
+    vidme: {
+      format: null
+    },
+    file: {
+      attributes: {},
+      tracks: [],
+      forceAudio: false,
+      forceHLS: false,
+      forceDASH: false
+    },
+    wistia: {
+      options: {}
+    }
   },
   onReady: function () {},
   onStart: function () {},
@@ -110,3 +130,14 @@ export const defaultProps = {
   onDuration: function () {},
   onProgress: function () {}
 }
+
+export const DEPRECATED_CONFIG_PROPS = [
+  'soundcloudConfig',
+  'youtubeConfig',
+  'facebookConfig',
+  'dailymotionConfig',
+  'vimeoConfig',
+  'vidmeConfig',
+  'fileConfig',
+  'wistiaConfig'
+]

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,7 @@
+import merge from 'lodash.merge'
+
+import { DEPRECATED_CONFIG_PROPS } from './props'
+
 const MATCH_START_QUERY = /[?&#](?:start|t)=([0-9hms]+)/
 const MATCH_START_STAMP = /(\d+)(h|m|s)/g
 const MATCH_NUMERIC = /^\d+$/
@@ -29,4 +33,20 @@ function parseStartStamp (stamp) {
     array = MATCH_START_STAMP.exec(stamp)
   }
   return seconds
+}
+
+export function getConfig (props, defaultProps, showWarning) {
+  const config = merge({}, defaultProps.config, props.config)
+  for (let p of DEPRECATED_CONFIG_PROPS) {
+    if (props[p]) {
+      const key = p.replace(/Config$/, '')
+      merge(config, { [key]: props[p] })
+      if (showWarning) {
+        const link = 'https://github.com/CookPete/react-player#config-prop'
+        const message = `ReactPlayer: %c${p} %cis deprecated, please use the config prop instead – ${link}`
+        console.warn(message, 'font-weight: bold', '')
+      }
+    }
+  }
+  return config
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,15 +214,9 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
-async@^2.1.2, async@^2.4.1:
+async@^2.1.2, async@^2.1.5, async@^2.4.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
-  dependencies:
-    lodash "^4.14.0"
-
-async@^2.1.5:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.3.0.tgz#1013d1051047dd320fe24e494d5c66ecaf6147d9"
   dependencies:
     lodash "^4.14.0"
 
@@ -3393,6 +3387,10 @@ lodash.memoize@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
+lodash.merge@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
 lodash.mergewith@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
@@ -5085,7 +5083,7 @@ style-loader@^0.18.2:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
-supports-color@3.1.2:
+supports-color@3.1.2, supports-color@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -5095,7 +5093,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.0, supports-color@^3.2.3:
+supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
I don't like how we have to carry around four separate `config` props in several places, especially for props that I think aren't used that often. This consolidates all the players' configuration data into one `config` prop, which falls back to a `defaultConfig` object for any property that isn't specified.

Still not sure if this is better than the current way of doing things. I'm happy to hear feedback if anyone has any.

This is definitely a breaking change and perhaps should wait until we're ready for a `v1.0` release.
