### PR TITLE
Add support for non-es5 compatible browsers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,11 @@
       "presets": ["react-hmre"]
     },
     "production": {
-      "plugins": ["add-module-exports"]
+      "plugins": [
+        "add-module-exports",
+        "transform-es3-member-expression-literals",
+        "transform-es3-property-literals"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "babel-eslint": "^6.0.2",
     "babel-loader": "^6.2.0",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
+    "babel-plugin-transform-es3-property-literals": "^6.8.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.0.1",


### PR DESCRIPTION
Hi @CookPete ! This adds two babel plugins that will make it possible to run non-dist code in non-es5 compatible environments. As far as I can tell this has no further effect on the codebase (tests passed fine locally).

http://babeljs.io/docs/plugins/transform-es3-member-expression-literals/
http://babeljs.io/docs/plugins/transform-es3-property-literals/