### PR TITLE
Fix buildup of multiple message event listeners

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -33,6 +33,10 @@ export default class Vimeo extends Base {
 
     super.componentDidMount()
   }
+  componentWillUnmount () {
+    window.removeEventListener('message', this.onMessage)
+    super.componentWillUnmount()
+  }
   getIframeParams () {
     return { ...DEFAULT_IFRAME_PARAMS, ...this.props.vimeoConfig.iframeParams }
   }


### PR DESCRIPTION
When loading/reloading multiple vimeo players, there is a build up of message event listeners on the global window object, because there is no detach on unmount.