### PR TITLE
Add support for a `startOffset` (FilePlayer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Prop | Description | Default
 `className` | Pass in a `className` to set on the root element
 `style` | Add [inline styles](https://facebook.github.io/react/tips/inline-styles.html) to the root element
 `progressFrequency` | The time between `onProgress` callbacks, in milliseconds | `1000`
+`startOffset` | The offset at which the player will start, in seconds. Works with FilePlayer only. | `0`
 
 #### Callback props
 

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -31,7 +31,8 @@ export default class ReactPlayer extends Component {
       this.props.playing !== nextProps.playing ||
       this.props.volume !== nextProps.volume ||
       this.props.height !== nextProps.height ||
-      this.props.width !== nextProps.width
+      this.props.width !== nextProps.width ||
+      this.props.startOffset !== nextProps.startOffset
     )
   }
   seekTo = fraction => {

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -16,7 +16,8 @@ export default class App extends Component {
     volume: 0.8,
     played: 0,
     loaded: 0,
-    duration: 0
+    duration: 0,
+    startOffset: 0
   }
   load = url => {
     this.setState({
@@ -60,6 +61,11 @@ export default class App extends Component {
     }
     this.setState(config)
   }
+  onStartOffsetUpdate = (e) => {
+    this.setState({
+      startOffset: Number.parseFloat(e.target.value)
+    })
+  }
   renderLoadButton = (url, label) => {
     return (
       <button onClick={() => this.load(url)}>
@@ -74,7 +80,8 @@ export default class App extends Component {
       soundcloudConfig,
       vimeoConfig,
       youtubeConfig,
-      fileConfig
+      fileConfig,
+      startOffset
     } = this.state
     const SEPARATOR = ' · '
 
@@ -102,6 +109,7 @@ export default class App extends Component {
             onError={e => console.log('onError', e)}
             onProgress={this.onProgress}
             onDuration={duration => this.setState({ duration })}
+            startOffset={startOffset}
           />
 
           <table><tbody>
@@ -183,6 +191,12 @@ export default class App extends Component {
               <td>
                 <textarea ref='config' placeholder='Enter JSON'></textarea>
                 <button onClick={this.onConfigSubmit}>Update Config</button>
+              </td>
+            </tr>
+            <tr>
+              <th>Start offset in seconds<br />(works with Files only)</th>
+              <td>
+                <input type='number' onChange={this.onStartOffsetUpdate} />
               </td>
             </tr>
           </tbody></table>

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -8,14 +8,16 @@ export default class FilePlayer extends Base {
   static canPlay (url) {
     return true
   }
-  static defaultProps = Object.assign({
-    startOffset: 0
-  }, Base.defaultProps)
+  static defaultProps = {
+    startOffset: 0,
+    ...Base.defaultProps
+  }
   constructor (props) {
     super(props)
-    this.state = Object.assign({
-      startOffset: 0
-    }, this.state)
+    this.state = {
+      startOffset: 0,
+      ...this.state,
+    }
   }
   componentWillReceiveProps ({ startOffset }) {
     super.componentWillReceiveProps(...arguments)

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -16,7 +16,7 @@ export default class FilePlayer extends Base {
     super(props)
     this.state = {
       startOffset: 0,
-      ...this.state,
+      ...this.state
     }
   }
   componentWillReceiveProps ({ startOffset }) {

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -1,5 +1,4 @@
 import React from 'react'
-
 import Base from './Base'
 
 const AUDIO_EXTENSIONS = /\.(mp3|wav|m4a)($|\?)/i
@@ -9,6 +8,27 @@ export default class FilePlayer extends Base {
   static canPlay (url) {
     return true
   }
+  static defaultProps = Object.assign({
+    startOffset: 0
+  }, Base.defaultProps)
+  constructor (props) {
+    super(props)
+    this.state = Object.assign({
+      startOffset: 0
+    }, this.state)
+  }
+  componentWillReceiveProps ({ startOffset }) {
+    super.componentWillReceiveProps(...arguments)
+    if (startOffset !== this.props.startOffset) {
+      const duration = this.player.duration - startOffset
+      this.safelyUpdateStartOffset(startOffset)
+      if (duration > 0) {
+        const newFraction = Math.max(0, this.player.currentTime - startOffset) / duration
+        super.seekTo(newFraction)
+        this.player.currentTime = duration * newFraction + startOffset
+      }
+    }
+  }
   componentDidMount () {
     this.player = this.refs.player
     this.player.oncanplay = this.onReady
@@ -17,13 +37,38 @@ export default class FilePlayer extends Base {
     this.player.onended = () => this.props.onEnded()
     this.player.onerror = e => this.props.onError(e)
     this.player.setAttribute('webkit-playsinline', '')
+    this.player.addEventListener('loadedmetadata', this.onLoadedMetaData)
     super.componentDidMount()
+  }
+  shouldComponentUpdate ({ startOffset }) {
+    return super.shouldComponentUpdate(...arguments) || startOffset !== this.props.startOffset
+  }
+  onLoadedMetaData = () => {
+    this.safelyUpdateStartOffset(this.props.startOffset)
+  }
+  safelyUpdateStartOffset = (startOffset) => {
+    if (startOffset < 0) {
+      this.setState({
+        startOffset: 0
+      })
+      console.warn("Cannot set `startOffset` to a negative value. `startOffset` falls back to it's default (0).")
+    } else if (this.player.duration > startOffset) {
+      this.setState({
+        startOffset: startOffset || 0
+      })
+    } else {
+      this.setState({
+        startOffset: 0
+      })
+      console.warn("Cannot set `startOffset` to a value superior to media's `duration`. `startOffset` falls back to it's default (0).")
+    }
   }
   load (url) {
     this.player.src = url
   }
   play () {
     this.player.play()
+    if (this.player.currentTime < this.state.startOffset) this.seekTo(0)
   }
   pause () {
     this.player.pause()
@@ -33,23 +78,26 @@ export default class FilePlayer extends Base {
     this.player.removeAttribute('src')
   }
   seekTo (fraction) {
+    const { startOffset } = this.state
     super.seekTo(fraction)
-    this.player.currentTime = this.getDuration() * fraction
+    this.player.currentTime = this.getDuration() * fraction + startOffset
   }
   setVolume (fraction) {
     this.player.volume = fraction
   }
   getDuration () {
+    const { startOffset } = this.state
     if (!this.isReady) return null
-    return this.player.duration
+    return this.player.duration - startOffset
   }
   getFractionPlayed () {
+    const { startOffset } = this.state
     if (!this.isReady) return null
-    return this.player.currentTime / this.getDuration()
+    return (this.player.currentTime - startOffset) / this.getDuration()
   }
   getFractionLoaded () {
     if (!this.isReady || this.player.buffered.length === 0) return null
-    return this.player.buffered.end(0) / this.getDuration()
+    return Math.min(this.player.buffered.end(0) / this.getDuration(), 1)
   }
   render () {
     const { loop, controls, fileConfig } = this.props

--- a/src/props.js
+++ b/src/props.js
@@ -8,6 +8,7 @@ export const propTypes = {
   volume: PropTypes.number,
   width: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
   height: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
+  startOffset: PropTypes.number,
   className: PropTypes.string,
   style: PropTypes.object,
   progressFrequency: PropTypes.number,


### PR DESCRIPTION
The player will start playing at the given offset (in seconds).

**`startOffset` prop** : 
- default value is `0`
- is coerced (minimum `0`, maximum `player.duration`). Any forbidden value will be overwritten by default `0` (internal state), and a warning will be flushed to the console.
- is fully reactive: any update to a higher value then current playing cursor value will result in the update of the playing cursor value (`player.currentTime`).

**Following `FilePlayer` methods now use `startOffset` to compute their return values**
- `getDuration`
- `getFractionPlayed`
- `getFractionLoaded`

You can test this feature in the demo app !

  