### PR TITLE
Add `hidden` prop to ReactPlayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Prop | Description | Default
 `volume` | Sets the volume of the appropriate player | `0.8`
 `width` | Sets the width of the player | `640`
 `height` | Sets the height of the player | `360`
+`hidden` | Set to `true` to hide the player | `false`
 `className` | Pass in a `className` to set on the root element
 `style` | Add [inline styles](https://facebook.github.io/react/tips/inline-styles.html) to the root element
 `progressFrequency` | The time between `onProgress` callbacks, in milliseconds | `1000`

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -94,7 +94,7 @@ export default class ReactPlayer extends Component {
       height: this.props.height
     }
     return (
-      <div style={style} className={this.props.className}>
+      <div style={style} className={this.props.className} hidden={this.props.hidden}>
         {this.renderPlayers()}
       </div>
     )

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -31,7 +31,8 @@ export default class ReactPlayer extends Component {
       this.props.playing !== nextProps.playing ||
       this.props.volume !== nextProps.volume ||
       this.props.height !== nextProps.height ||
-      this.props.width !== nextProps.width
+      this.props.width !== nextProps.width ||
+      this.props.hidden !== nextProps.hidden
     )
   }
   seekTo = fraction => {

--- a/src/props.js
+++ b/src/props.js
@@ -8,6 +8,7 @@ export const propTypes = {
   volume: PropTypes.number,
   width: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
   height: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
+  hidden: PropTypes.bool,
   className: PropTypes.string,
   style: PropTypes.object,
   progressFrequency: PropTypes.number,

--- a/src/props.js
+++ b/src/props.js
@@ -43,6 +43,7 @@ export const defaultProps = {
   volume: 0.8,
   width: 640,
   height: 360,
+  hidden: false,
   progressFrequency: 1000,
   soundcloudConfig: {
     clientId: 'e8b6f84fbcad14c301ca1355cae1dea2'


### PR DESCRIPTION
**Description:**
`hidden` is a standard HTML prop of react. I was building a toggle feature to hide ReactPlayer -- as opposed to re-rendering the player each toggle, which would lag due to having to retrieve and re-embed the media each time -- and found that ReactPlayer does not accept a hidden prop to hide its top level div. In order to hide it using `hidden`, I had to write another parent div above ReactPlayer just to hide the component.

```es6
// Not the best way to hide a component
<div hidden={ myBoolean }>
  <ReactPlayer url={ this.props.randomURL }>
</div>
```

**Changes Proposed:** 
I'd like to propose that `hidden` be added to one of the standard props ReactPlayer accepts (alongside the standard `style` & `className` props). Like so:

```es6
// Feels better this way!
<ReactPlayer
  url={ this.props.randomURL }
  hidden={ myBoolean }
/>
```

I've included working code that allows this very use case in this PR. I've also included a line to the `Props` documentation in README.md about `hidden` as a prop that can hide ReactPlayer.