### PR TITLE
add iframe style for vimeo player

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -107,12 +107,12 @@ export default class Vimeo extends Base {
     this.iframe = iframe
   }
   render () {
-    const { fullscreen } = this.getIframeParams()
+    const { fullscreen, iframeStyle = {} } = this.getIframeParams()
     const style = {
       display: this.props.url ? 'block' : 'none',
       width: '100%',
-      height: '100%'
-    }
+      height: '100%',
+      ...iframeStyle}
     return (
       <iframe
         ref={this.ref}


### PR DESCRIPTION
this PR aim to accept style setting from IframeParams, apply iframe style. it will allow user to specify unfixed width and height of player container element (this will remove the black side bar in player container). use case as below:

``` js
 <div style={{ width: '100%', height: '0', position: 'relative', paddingBottom: '56.25%' }} >
        <iframe
          style={{ width: '100%', height: '100%', position: 'absolute', top: '0', left: '0' }}
```
