### PR TITLE
Add additional audio file extensions to regex

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import Base from './Base'
 
-const AUDIO_EXTENSIONS = /\.(mp3|wav|m4a)($|\?)/i
+const AUDIO_EXTENSIONS = /\.(m4a|mp4a|mpga|mp2|mp2a|mp3|m2a|m3a|wav|weba|aac|oga|ogg|spx)($|\?)/i
 
 export default class FilePlayer extends Base {
   static displayName = 'FilePlayer'


### PR DESCRIPTION
Based on [this list](https://en.wikipedia.org/wiki/HTML5_Audio#Supported_audio_coding_formats) of audio formats supported by the `<audio>` element. File extensions for supported formats pulled from  [this source](http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types).