### PR TITLE
Use ubuntu 14.04 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+dist: trusty
 addons:
   apt:
     packages:


### PR DESCRIPTION
https://docs.travis-ci.com/user/trusty-ci-environment/

Because by default travis uses 12.04, which is pretty old and contains old versions of Chromium / Firefox. It would be good to test on slightly more up to date browsers, like Chromium 53 instead of 38.