### PR TITLE
play pause bug in fileplayer.js

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -45,8 +45,11 @@ export default class FilePlayer extends Base {
     this.player.removeAttribute('src')
   }
   seekTo (fraction) {
+    if (fraction === 1) {
+      this.pause();
+    }
     super.seekTo(fraction)
-    this.player.currentTime = this.getDuration() * fraction
+    this.player.currentTime = this.getDuration() * fraction;
   }
   setVolume (fraction) {
     this.player.volume = fraction


### PR DESCRIPTION
fixed bug that triggered play() and pause() at the same time when seekTo() is called at fraction === 1 (100% of file duration)