### PR TITLE
Ensure that the YouTube `<iframe />` is really in the DOM before calling

### DIFF
--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -108,8 +108,13 @@ export default class YouTube extends Base {
     this.player.pauseVideo()
   }
   stop () {
-    if (!this.isReady || !this.player.stopVideo || !this.player.getIframe()) return
-    this.player.stopVideo()
+    const playerNode = this.player && this.player.getIframe && this.player.getIframe();
+    // the iframe is cached, so we need to try and retrieve it from the
+    // document to be sure of its existence in the DOM.
+    const isPlayerInDOM = !!document.getElementById(playerNode && playerNode.id);
+
+    if (!this.isReady || !this.player.stopVideo || !isPlayerInDOM) return;
+    this.player.stopVideo();
   }
   seekTo (fraction) {
     super.seekTo(fraction)

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -108,7 +108,7 @@ export default class YouTube extends Base {
     this.player.pauseVideo()
   }
   stop () {
-    if (!this.isReady || !this.player.stopVideo) return
+    if (!this.isReady || !this.player.stopVideo || !this.player.getIframe()) return
     this.player.stopVideo()
   }
   seekTo (fraction) {

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -108,13 +108,13 @@ export default class YouTube extends Base {
     this.player.pauseVideo()
   }
   stop () {
-    const playerNode = this.player && this.player.getIframe && this.player.getIframe();
+    const playerNode = this.player && this.player.getIframe && this.player.getIframe()
     // the iframe is cached, so we need to try and retrieve it from the
     // document to be sure of its existence in the DOM.
-    const isPlayerInDOM = !!document.getElementById(playerNode && playerNode.id);
+    const isPlayerInDOM = !!document.getElementById(playerNode && playerNode.id)
 
-    if (!this.isReady || !this.player.stopVideo || !isPlayerInDOM) return;
-    this.player.stopVideo();
+    if (!this.isReady || !this.player.stopVideo || !isPlayerInDOM) return
+    this.player.stopVideo()
   }
   seekTo (fraction) {
     super.seekTo(fraction)


### PR DESCRIPTION
This just ensures that the iFrame is mounted in the DOM before calling `this.player.stopVideo()`, or else an uncaught error results. I encountered this in the course of embedding this component in a draft-js based editor with cut and paste operations, causing the iFrame to be removed from the DOM before `componentWillUnmount` was called.