### PR TITLE
Apply all non-valid props to the wrapper element

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ Prop | Description | Default
 `playbackRate` | Sets the playback rate of the appropriate player | `1`
 `width` | Sets the width of the player | `640`
 `height` | Sets the height of the player | `360`
-`hidden` | Set to `true` to hide the player | `false`
-`className` | Pass in a `className` to set on the root element
 `style` | Add [inline styles](https://facebook.github.io/react/tips/inline-styles.html) to the root element
 `progressFrequency` | The time between `onProgress` callbacks, in milliseconds | `1000`
 `playsinline` | Applies the `playsinline` attribute where supported | `false`

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   "dependencies": {
     "fetch-jsonp": "^1.0.2",
     "load-script": "^1.0.0",
+    "lodash.omit": "^4.5.0",
     "prop-types": "^15.5.6",
     "query-string": "^4.2.3"
   },

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import omit from 'lodash.omit'
 
 import { propTypes, defaultProps } from './props'
 import YouTube from './players/YouTube'
@@ -123,10 +124,11 @@ export default class ReactPlayer extends Component {
     )
   }
   render () {
-    const { style, width, height, className, hidden } = this.props
+    const { style, width, height } = this.props
+    const otherProps = omit(this.props, Object.keys(propTypes))
     const players = this.renderPlayers()
     return (
-      <div style={{ ...style, width, height }} className={className} hidden={hidden}>
+      <div style={{ ...style, width, height }} {...otherProps}>
         {players}
       </div>
     )

--- a/src/props.js
+++ b/src/props.js
@@ -11,8 +11,6 @@ export const propTypes = {
   playbackRate: number,
   width: oneOfType([ string, number ]),
   height: oneOfType([ string, number ]),
-  hidden: bool,
-  className: string,
   style: object,
   progressFrequency: number,
   playsinline: bool,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3345,6 +3345,10 @@ lodash.mergewith@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
 
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+
 lodash.tail@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"


### PR DESCRIPTION
Possible fix for https://github.com/CookPete/react-player/issues/167

@oyeanuj any thoughts on this? The only possible issue is that we now call lodash's `omit` on every render, but I'm not sure it will affect performance that badly.