### PR TITLE
Fix initial loading bug for Private Vimeo videos

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -57,7 +57,7 @@ export default class Vimeo extends Base {
       this.player = new Vimeo.Player(this.container, {
         ...DEFAULT_OPTIONS,
         ...this.props.vimeoConfig.playerOptions,
-        id,
+        url,
         loop: this.props.loop
       })
       this.player.on('loaded', () => {


### PR DESCRIPTION
Private Vimeo videos have the structure `https://vimeo.com/<number>/<hex>`. For some reason, when passing just the ID to the initial player, it chokes with errors. When the player is already loaded, using the ID seems to work fine.