### PR TITLE
More accurate played fraction for Wistia

### DIFF
--- a/src/players/Wistia.js
+++ b/src/players/Wistia.js
@@ -84,7 +84,7 @@ export default class Wistia extends Base {
   }
   getFractionPlayed () {
     if (!this.isReady || !this.player || !this.player.percentWatched) return null
-    return this.player.percentWatched()
+    return this.player.time() / this.player.duration()
   }
   getFractionLoaded () {
     return null


### PR DESCRIPTION
I noticed that the Wistia `percentWatched()` is actually pretty rough; it's only updated in chunks, which sucks if you need frame precision. To fix this, I’ve reimplemented the `getFractionPlayed()` calculation to use the Wistia `time()` and `duration()` methods, which are always 100% accurate.