### PR TITLE
Updated TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,52 +12,80 @@ export interface TrackProps {
   default?: boolean;
 }
 
+export interface SoundCloudConfig {
+  options?: Object;
+}
+
+export interface YouTubeConfig {
+  playerVars?: Object;
+  preload?: boolean;
+}
+
+export interface FacebookConfig {
+  appId: string;
+}
+
+export interface DailyMotionConfig {
+  params?: Object;
+  preload?: boolean;
+}
+
+export interface VimeoConfig {
+  iframeParams?: Object;
+  preload?: boolean;
+}
+
+export interface VidmeConfig {
+  format?: string;
+}
+
+export interface WistiaConfig {
+  options?: Object;
+}
+
+export interface FileConfig {
+  attributes?: Object;
+  tracks?: TrackProps[];
+  forceAudio?: boolean;
+  forceHLS?: boolean;
+  forceDASH?: boolean;
+}
+
+export interface Config {
+  soundcloud?: SoundCloudConfig;
+  youtube?: YouTubeConfig;
+  facebook?: FacebookConfig;
+  dailymotion?: DailyMotionConfig;
+  vimeo?: VimeoConfig;
+  vidme?: VidmeConfig;
+  file?: FileConfig;
+  wistia?: WistiaConfig;
+}
+
 export interface ReactPlayerProps {
-  url?: string|string[]|SourceProps[];
+  url?: string | string[] | SourceProps[];
   playing?: boolean;
   loop?: boolean;
   controls?: boolean;
   volume?: number;
   muted?: boolean;
   playbackRate?: number;
-  width?: string|number;
-  height?: string|number;
+  width?: string | number;
+  height?: string | number;
   style?: Object;
   progressFrequency?: number;
   playsinline?: boolean;
   hidden?: boolean;
   className?: string;
-  soundcloudConfig?: {
-    options: Object;
-  };
-  youtubeConfig?: {
-    playerVars: Object;
-    preload: boolean;
-  };
-  facebookConfig?: {
-    appId: string;
-  };
-  dailymotionConfig?: {
-    params: Object;
-    preload: boolean;
-  };
-  vimeoConfig?: {
-    iframeParams: Object;
-    preload: boolean;
-  };
-  vidmeConfig?: {
-    format: string;
-  };
-  fileConfig?: {
-    attributes: Object;
-    tracks: TrackProps[];
-    forceAudio: boolean;
-    forceHLS: boolean;
-    forceDASH: boolean;
-  };
-  wistiaConfig?: {
-    options: Object;
-  };
+  config?: Config;
+  soundcloudConfig?: SoundCloudConfig;
+  youtubeConfig?: YouTubeConfig;
+  facebookConfig?: FacebookConfig;
+  dailymotionConfig?: DailyMotionConfig;
+  vimeoConfig?: VimeoConfig;
+  vidmeConfig?: VidmeConfig;
+  fileConfig?: FileConfig;
+  wistiaConfig?: WistiaConfig;
   onReady?(): void;
   onStart?(): void;
   onPlay?(): void;


### PR DESCRIPTION
This PR will update the TS typings, as they seem to have gone out of date with the 2.4 config changes.

I've made each property in each config optional, as from what I can tell, most of them have defaults and are not mandatory. It also allows the authors to pass in partial objects (file config with just `attributes` instead of forcing you to define `tracks`, `forceAudio`, etc.)

Each individual config for each video provider are also now their own exported interfaces so you can reuse the types without having to recreate them yourself in cases like this:

```TS
import ReactPlayer, { FileConfig, TrackProps } from "react-player";

// ...
const getTracks = (): TrackProps[] => {
  // Whatever get tracks does...
}

// ...
const fileConfig: FileConfig = {
  tracks: getTracks(),
}

// ...
<ReactPlayer config={{ file: fileConfig }} />
```