### PR TITLE
Fix Vimeo instantiation error catching

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -39,27 +39,29 @@ export default class Vimeo extends Base {
         url,
         loop: this.props.loop
       })
-      this.player.on('loaded', () => {
-        this.onReady()
-        const iframe = this.container.querySelector('iframe')
-        iframe.style.width = '100%'
-        iframe.style.height = '100%'
-      })
-      this.player.on('play', ({ duration }) => {
-        this.duration = duration
-        this.onPlay()
-      })
-      this.player.on('pause', this.props.onPause)
-      this.player.on('seeked', e => this.props.onSeek(e.seconds))
-      this.player.on('ended', this.props.onEnded)
-      this.player.on('error', this.props.onError)
-      this.player.on('timeupdate', ({ seconds }) => {
-        this.currentTime = seconds
-      })
-      this.player.on('progress', ({ seconds }) => {
-        this.secondsLoaded = seconds
-      })
-    }, this.props.onError)
+      this.player.ready().then( () => {
+        this.player.on('loaded', () => {
+          this.onReady()
+          const iframe = this.container.querySelector('iframe')
+          iframe.style.width = '100%'
+          iframe.style.height = '100%'
+        })
+        this.player.on('play', ({ duration }) => {
+          this.duration = duration
+          this.onPlay()
+        })
+        this.player.on('pause', this.props.onPause)
+        this.player.on('seeked', e => this.props.onSeek(e.seconds))
+        this.player.on('ended', this.props.onEnded)
+        this.player.on('error', this.props.onError)
+        this.player.on('timeupdate', ({ seconds }) => {
+          this.currentTime = seconds
+        })
+        this.player.on('progress', ({ seconds }) => {
+          this.secondsLoaded = seconds
+        })
+      }).catch( this.props.onError )
+    })
   }
   play () {
     this.callPlayer('play')


### PR DESCRIPTION
Errors happening during instantiation of the Vimeo player (for example: a private video or 404) were not caught and passed to the error handler. This resulted in a bunch of console errors (triggered by the `this.player.on(...)` calls after instantiation), a broken player, and no way to do anything about it or even tell the user what is going on.

This change calls `player.ready()` right after instantiation (which returns a [promise](https://github.com/vimeo/player.js/blob/master/src/lib/embed.js#L52)), allowing us to check if everything is OK (in which case we attach all the listeners), or not (in which case we pass the error on to our `onError` method).

More info: https://github.com/vimeo/player.js/issues/165