### PR TITLE
Update typings for onProgress callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,7 +93,7 @@ export interface ReactPlayerProps {
   onError?(error: any): void;
   onDuration?(duration: number): void;
   onSeek?(seconds: number): void;
-  onProgress?(state: { played: number, loaded: number }): void;
+  onProgress?(state: { played: number, playedSeconds: number, loaded: number, loadedSeconds: number }): void;
 }
 
 export default class ReactPlayer extends React.Component<ReactPlayerProps, any> {


### PR DESCRIPTION
Hi! The `onProgress` callback is incompletely specified in `index.d.ts` - according to the README it also receives `playedSeconds` and `loadedSeconds`, but they're not mentioned in the Typescript definition file. This PR adds them.