### PR TITLE
tweak Vimeo duration logic

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -28,7 +28,9 @@ export default class Vimeo extends Base {
     const id = url.match(MATCH_URL)[3]
     this.duration = null
     if (this.isReady) {
-      this.player.loadVideo(id).catch(this.props.onError)
+      this.player.loadVideo(id)
+        .then(this.setDuration)
+        .catch(this.props.onError)
       return
     }
     if (this.loadingSDK) {
@@ -46,9 +48,7 @@ export default class Vimeo extends Base {
         const iframe = this.container.querySelector('iframe')
         iframe.style.width = '100%'
         iframe.style.height = '100%'
-        this.player.getDuration().then(duration => {
-          this.duration = duration
-        })
+        this.setDuration()
       }).catch(this.props.onError)
       this.player.on('loaded', this.onReady)
       this.player.on('play', this.onPlay)
@@ -63,6 +63,11 @@ export default class Vimeo extends Base {
         this.secondsLoaded = seconds
       })
     }, this.props.onError)
+  }
+  setDuration () {
+    this.player.getDuration().then(duration => {
+      this.duration = duration
+    })
   }
   play () {
     this.callPlayer('play')

--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -28,9 +28,7 @@ export default class Vimeo extends Base {
     const id = url.match(MATCH_URL)[3]
     this.duration = null
     if (this.isReady) {
-      this.player.loadVideo(id)
-        .then(this.setDuration)
-        .catch(this.props.onError)
+      this.player.loadVideo(id).catch(this.props.onError)
       return
     }
     if (this.loadingSDK) {
@@ -48,9 +46,13 @@ export default class Vimeo extends Base {
         const iframe = this.container.querySelector('iframe')
         iframe.style.width = '100%'
         iframe.style.height = '100%'
-        this.setDuration()
       }).catch(this.props.onError)
-      this.player.on('loaded', this.onReady)
+      this.player.on('loaded', () => {
+        this.onReady()
+        this.player.getDuration().then(duration => {
+          this.duration = duration
+        })
+      })
       this.player.on('play', this.onPlay)
       this.player.on('pause', this.props.onPause)
       this.player.on('seeked', e => this.props.onSeek(e.seconds))
@@ -63,11 +65,6 @@ export default class Vimeo extends Base {
         this.secondsLoaded = seconds
       })
     }, this.props.onError)
-  }
-  setDuration () {
-    this.player.getDuration().then(duration => {
-      this.duration = duration
-    })
   }
   play () {
     this.callPlayer('play')


### PR DESCRIPTION
Hey!
It's about that issue: https://github.com/CookPete/react-player/issues/250
If we want to add setDuration logic in `this.player.ready().then(...)` instead of `this.player.on("loaded")`, we also should to add the tweak from that PR.