### PR TITLE
seekOnPlay->seekOnDuration

### DIFF
--- a/src/players/Base.js
+++ b/src/players/Base.js
@@ -9,7 +9,7 @@ export default class Base extends Component {
   static defaultProps = defaultProps
   isReady = false
   startOnPlay = true
-  seekOnPlay = null
+  seekOnDuration = null
   componentDidMount () {
     const { url } = this.props
     this.mounted = true
@@ -25,7 +25,7 @@ export default class Base extends Component {
     const { url, playing, volume, muted, playbackRate } = this.props
     // Invoke player methods based on incoming props
     if (url !== nextProps.url && nextProps.url) {
-      this.seekOnPlay = null
+      this.seekOnDuration = null
       this.startOnPlay = true
       this.load(nextProps.url)
     }
@@ -72,9 +72,9 @@ export default class Base extends Component {
   seekTo (amount) {
     // When seeking before player is ready, store value and seek later
     if (!this.isReady && amount !== 0) {
-      this.seekOnPlay = amount
+      this.seekOnDuration = amount
       setTimeout(() => {
-        this.seekOnPlay = null
+        this.seekOnDuration = null
       }, SEEK_ON_PLAY_EXPIRY)
     }
     // Return the seconds to seek to
@@ -95,11 +95,6 @@ export default class Base extends Component {
       this.startOnPlay = false
     }
     onPlay()
-    if (this.seekOnPlay) {
-      this.seekTo(this.seekOnPlay)
-      this.seekOnPlay = null
-    }
-    this.onDurationCheck()
   }
   onReady = () => {
     const { onReady, playing } = this.props
@@ -122,6 +117,10 @@ export default class Base extends Component {
     const duration = this.getDuration()
     if (duration) {
       this.props.onDuration(duration)
+      if (this.seekOnDuration) {
+        this.seekTo(this.seekOnDuration)
+        this.seekOnDuration = null
+      }
     } else {
       this.durationCheckTimeout = setTimeout(this.onDurationCheck, 100)
     }

--- a/src/players/Facebook.js
+++ b/src/players/Facebook.js
@@ -57,7 +57,7 @@ export default class Facebook extends Base {
   }
   seekTo (amount) {
     const seconds = super.seekTo(amount)
-    this.player.seek(seconds)
+    this.callPlayer('seek', seconds)
   }
   setVolume (fraction) {
     if (fraction !== 0) {

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -119,7 +119,10 @@ export default class FilePlayer extends Base {
   }
   seekTo (amount) {
     const seconds = super.seekTo(amount)
-    this.player.currentTime = seconds
+    if (seconds || seconds === 0) {
+      // it will looked better when ReactPlayer structure will migrated to composition
+      this.player.currentTime = seconds
+    }
   }
   setVolume (fraction) {
     this.player.volume = fraction

--- a/src/players/Twitch.js
+++ b/src/players/Twitch.js
@@ -21,9 +21,12 @@ export default class Twitch extends Base {
     const id = isChannel ? url.match(MATCH_CHANNEL_URL)[1] : url.match(MATCH_VIDEO_URL)[1]
     if (this.isReady) {
       if (isChannel) {
+        this.props.onDuration(Infinity)
         this.player.setChannel(id)
       } else {
+        this.prevDuration = this.getDuration()
         this.player.setVideo('v' + id)
+        this.checkDurationChange()
       }
       return
     }
@@ -54,6 +57,14 @@ export default class Twitch extends Base {
     }
     onEnded()
   }
+  checkDurationChange = () => {
+    const duration = this.getDuration()
+    if (duration && duration !== this.prevDuration) {
+      this.props.onDuration(duration)
+    } else {
+      setTimeout(this.checkDurationChange, 100)
+    }
+  }
   play () {
     this.callPlayer('play')
   }
@@ -71,7 +82,9 @@ export default class Twitch extends Base {
     this.callPlayer('setVolume', fraction)
   }
   getDuration () {
-    return this.callPlayer('getDuration')
+    const duration = this.callPlayer('getDuration')
+    if (isFinite(duration)) return duration || null
+    return null
   }
   getCurrentTime () {
     return this.callPlayer('getCurrentTime')

--- a/src/players/Twitch.js
+++ b/src/players/Twitch.js
@@ -15,6 +15,10 @@ export default class Twitch extends Base {
     return MATCH_VIDEO_URL.test(url) || MATCH_CHANNEL_URL.test(url)
   }
   playerID = PLAYER_ID_PREFIX + randomString()
+  durationCheckChangeTimeout = null // it's bad naming, but durationCheckTimeout reserved by Base
+  componentWillUnmount() {
+    clearTimeout(this.durationCheckChangeTimeout)
+  }
   load (url) {
     const { playsinline, onError } = this.props
     const isChannel = MATCH_CHANNEL_URL.test(url)
@@ -62,7 +66,7 @@ export default class Twitch extends Base {
     if (duration && duration !== this.prevDuration) {
       this.props.onDuration(duration)
     } else {
-      setTimeout(this.checkDurationChange, 100)
+      this.durationCheckChangeTimeout = setTimeout(this.checkDurationChange, 100)
     }
   }
   play () {


### PR DESCRIPTION
Hi, there!
At current time, when seeking before ActivePlayer is `ready`, ReactPlayer store seeking value and await for `play`. But if we don't playing by default and user seeking when player is not `ready`, we expect seeking at once when it possible. But at current time (in described case) user should press on `play`: before it seeking have not applied.
That PR fixes that behavior.

Inside of PR:
- `seekOnPlay` -> `seekOnDuration`
- protection from Infinity in `getDuration` of Twitch
- removing `this.onDurationCheck()` from `this.onPlay()` of Base (in code from PR `this.props.onDuration()` executes once per media, excluding logic of DailyMotion player)
- adding `this.checkDurationChange()` in Twitch
- passing Infinity to `this.props.onDuration(duration)` in Twitch when playing channel

**!!! IMPORTANT !!!**
DailyMotion resource is not available for my country... It have listener `onDurationChange` and should works good. But it needs for test of emitting `this.props.onDuration()` anyway.