### PR TITLE
properly destroy HLS.JS and / or DASH.JS instances

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -114,7 +114,10 @@ export default class FilePlayer extends Base {
   stop () {
     this.player.removeAttribute('src')
     if (this.hls) {
-      this.hls.detachMedia()
+      this.hls.destroy()
+    }
+    if (this.dash) {
+      this.dash.reset()
     }
   }
   seekTo (amount) {


### PR DESCRIPTION
I noticed the hls.js instance is still downloading the m3u8 playlist after the player is destroyed, so I figured this should fix this. Also, this way we're properly clearing up memory leaks.