### PR TITLE
Soundcloud implementation with SC.stream to avoid focus problems

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -35,6 +35,7 @@ export default class Player extends Component {
   componentWillReceiveProps (nextProps) {
     // Invoke player methods based on incoming props
     const { activePlayer, url, playing, volume, muted, playbackRate } = this.props
+
     if (activePlayer !== nextProps.activePlayer) {
       this.player.stop()
       return // A new player is coming, so don't invoke any other methods
@@ -155,12 +156,14 @@ export default class Player extends Component {
   }
   render () {
     const Player = this.props.activePlayer
+
     return (
       <Player
         {...this.props}
         ref={this.ref}
         onReady={this.onReady}
         onPlay={this.onPlay}
+        onPause={this.onPause}
         onEnded={this.onEnded}
       />
     )

--- a/src/players/SoundCloud.js
+++ b/src/players/SoundCloud.js
@@ -2,43 +2,70 @@ import React, { Component } from 'react'
 
 import { callPlayer, getSDK } from '../utils'
 
-const SDK_URL = 'https://w.soundcloud.com/player/api.js'
+const SDK_URL = 'https://connect.soundcloud.com/sdk/sdk-3.0.0.js'
 const SDK_GLOBAL = 'SC'
 const MATCH_URL = /^https?:\/\/(soundcloud.com|snd.sc)\/([a-z0-9-_]+\/[a-z0-9-_]+)$/
+
+const ERRORS = ['geo_blocked', 'no_streams', 'no_connection', 'no_protocol', 'audio_error']
 
 export default class SoundCloud extends Component {
   static displayName = 'SoundCloud'
   static canPlay = url => MATCH_URL.test(url)
   static loopOnEnded = true
 
+  track = null
+
   callPlayer = callPlayer
   duration = null
   currentTime = null
   fractionLoaded = null
+
+  constructor (props, context) {
+    super(props, context)
+
+    this.state = {
+      track: null
+    }
+  }
+
+  pSetState (stateModifications) {
+    return new Promise((resolve, reject) => {
+      this.setState(stateModifications, resolve)
+    })
+  }
+
   load (url, isReady) {
     getSDK(SDK_URL, SDK_GLOBAL).then(SC => {
-      if (!this.iframe) return
-      const { PLAY, PLAY_PROGRESS, PAUSE, FINISH, ERROR } = SC.Widget.Events
       if (!isReady) {
-        this.player = SC.Widget(this.iframe)
-        this.player.bind(PLAY, this.props.onPlay)
-        this.player.bind(PAUSE, this.props.onPause)
-        this.player.bind(PLAY_PROGRESS, e => {
-          this.currentTime = e.currentPosition / 1000
-          this.fractionLoaded = e.loadedProgress
-        })
-        this.player.bind(FINISH, () => this.props.onEnded())
-        this.player.bind(ERROR, e => this.props.onError(e))
-      }
-      this.player.load(url, {
-        ...this.props.config.soundcloud.options,
-        callback: () => {
-          this.player.getDuration(duration => {
-            this.duration = duration / 1000
+        SC.initialize({ client_id: this.props.config.soundcloud.clientId })
+        SC.get('/resolve', { url: this.props.url })
+          .then((track) => {
+            return this.pSetState({ track })
+                       .then(() => track)
+          })
+          .then((track) => {
+            this.duration = track.duration / 1000
+            return SC.stream('/tracks/' + track.id, { autoPlay: true })
+          })
+          .then((player) => {
+            this.player = player
+
+            this.player.on('play', this.props.onPlay)
+            this.player.on('pause', this.props.onPause)
+            this.player.on('time', () => {
+              this.currentTime = this.player.controller._currentPosition / 1000
+              this.fractionLoaded = this.player.controller._loadedPosition
+            })
+            this.player.on('finish', () => this.props.onEnded())
+
+            ERRORS.forEach((error) => {
+              this.player.on(error, (e) => this.props.onError(e))
+            })
+
             this.props.onReady()
           })
-        }
-      })
+          .catch(console.error)
+      }
     })
   }
   play () {
@@ -48,13 +75,13 @@ export default class SoundCloud extends Component {
     this.callPlayer('pause')
   }
   stop () {
-    // Nothing to do
+    this.player.pause()
   }
   seekTo (seconds) {
-    this.callPlayer('seekTo', seconds * 1000)
+    this.callPlayer('seek', seconds * 1000)
   }
   setVolume (fraction) {
-    this.callPlayer('setVolume', fraction * 100)
+    this.callPlayer('setVolume', fraction)
   }
   getDuration () {
     return this.duration
@@ -65,21 +92,16 @@ export default class SoundCloud extends Component {
   getSecondsLoaded () {
     return this.fractionLoaded * this.duration
   }
-  ref = iframe => {
-    this.iframe = iframe
-  }
   render () {
     const style = {
       width: '100%',
       height: '100%'
     }
+
+    const artwork = this.state.track ? this.state.track.artwork_url : ''
+
     return (
-      <iframe
-        ref={this.ref}
-        src={`https://w.soundcloud.com/player/?url=${encodeURIComponent(this.props.url)}`}
-        style={style}
-        frameBorder={0}
-      />
+      <img src={artwork} style={style} />
     )
   }
 }

--- a/src/players/SoundCloud.js
+++ b/src/players/SoundCloud.js
@@ -64,7 +64,7 @@ export default class SoundCloud extends Component {
 
             this.props.onReady()
           })
-          .catch(console.error)
+          .catch(this.props.onError)
       }
     })
   }


### PR DESCRIPTION
might not be perfect but it's a start.
difference with the previous soundcloud implementation:
  - Use of the SC.stream instead of the iframe
  - Use of SC.get to retrieve the id of the track
  - A this.state was added to rerender the component and image with setState when the artwork is loaded
  - a pSetState was added to wrap setState into a promise
  - Errors are defined by multiple events by the soundcloud event emitter
  - The data is extracted from a subobject of the player : _controller
  - The volume does not need to be divided

SDK choice :
https://connect.soundcloud.com/sdk.js is an old 2.0 version, no promises
https://connect.soundcloud.com/sdk/sdk-3.2.2.js asks for a secret_token
3.0.0 was kept

BUG FOUND:
bug found at src/Player.js : this.onPause is not given as a parameter to the active Player:
When i paused my player i could not play it back.
i noticed that the internal `isPlaying` variable wasn't updated.
Ultimately it was the onPause callback that wasn't passed back to
the Player in the render function.
Adding it fixed my problem