### PR TITLE
Vimeo On Demand URL Support

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -4,7 +4,7 @@ import { callPlayer, getSDK } from '../utils'
 
 const SDK_URL = 'https://player.vimeo.com/api/player.js'
 const SDK_GLOBAL = 'Vimeo'
-const MATCH_URL = /https?:\/\/(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|album\/(\d+)\/video\/|video\/|)(\d+)(?:$|\/|\?)/
+const MATCH_URL = /https?:\/\/(?:www\.|player\.)?vimeo.com\/(?:(?:channels|ondemand)\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|album\/(\d+)\/video\/|video\/|)(\d+)(?:$|\/|\?)/
 
 export default class Vimeo extends Component {
   static displayName = 'Vimeo'

--- a/test/specs/canPlay.js
+++ b/test/specs/canPlay.js
@@ -42,6 +42,12 @@ describe('canPlay', () => {
     it('knows what it can play', () => {
       expect(Vimeo.canPlay('http://vimeo.com/1234')).to.be.true
       expect(Vimeo.canPlay('https://vimeo.com/1234')).to.be.true
+      expect(Vimeo.canPlay('https://www.vimeo.com/1234')).to.be.true
+      expect(Vimeo.canPlay('https://vimeo.com/ondemand/tinact/84954874')).to.be.true
+      expect(Vimeo.canPlay('https://vimeo.com/channels/staffpicks/40004005')).to.be.true
+      expect(Vimeo.canPlay('https://vimeo.com/groups/motion/videos/73234721')).to.be.true
+      expect(Vimeo.canPlay('https://vimeo.com/album/3953264/video/166790294')).to.be.true
+      expect(Vimeo.canPlay('https://player.vimeo.com/video/40004005')).to.be.true
     })
 
     it('knows what it can\'t play', () => {


### PR DESCRIPTION
Vimeo has On Demand URLs like https://vimeo.com/ondemand/tinact/84954874

Currently the player doesn't recognize them, so this PR adds support for them.

I also added some tests for other Vimeo URLs.