### PR TITLE
Do not load hls.js on iOS

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -80,7 +80,7 @@ export default class FilePlayer extends Component {
     return AUDIO_EXTENSIONS.test(props.url) || props.config.file.forceAudio
   }
   shouldUseHLS (url) {
-    const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+    const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
     return (HLS_EXTENSIONS.test(url) && !iOS) || this.props.config.file.forceHLS
   }
   shouldUseDASH (url) {

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -80,7 +80,8 @@ export default class FilePlayer extends Component {
     return AUDIO_EXTENSIONS.test(props.url) || props.config.file.forceAudio
   }
   shouldUseHLS (url) {
-    return HLS_EXTENSIONS.test(url) || this.props.config.file.forceHLS
+    const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+    return (HLS_EXTENSIONS.test(url) && !iOS) || this.props.config.file.forceHLS
   }
   shouldUseDASH (url) {
     return DASH_EXTENSIONS.test(url) || this.props.config.file.forceDASH


### PR DESCRIPTION
Safari mobile does not support media source extensions and thus will not work with hls.js. Use native HLS video support on iOS instead.

https://caniuse.com/#feat=mediasource