### PR TITLE
Match YouTube URL with extra parameters

### DIFF
--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -5,7 +5,7 @@ import { callPlayer, getSDK, parseStartTime } from '../utils'
 const SDK_URL = 'https://www.youtube.com/iframe_api'
 const SDK_GLOBAL = 'YT'
 const SDK_GLOBAL_READY = 'onYouTubeIframeAPIReady'
-const MATCH_URL = /(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})$/
+const MATCH_URL = /(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})/
 
 export default class YouTube extends Component {
   static displayName = 'YouTube'


### PR DESCRIPTION
If the regular expression expects the end of string after a video ID, many YouTube links (like https://youtu.be/YE7VzlLtp-4?t=17s for instance) won't match and pass the `canPlay` test.