### PR TITLE
Fixes the onPause event propogation

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -116,10 +116,10 @@ export default class Player extends Component {
     }
     this.onDurationCheck()
   }
-  onPause = () => {
+  onPause = (e) => {
     this.isPlaying = false
     if (!this.isLoading) {
-      this.props.onPause()
+      this.props.onPause(e)
     }
   }
   onEnded = () => {


### PR DESCRIPTION
If we pass an `onPause` handler to VideoPlayer, the event is not propagated and hence not able to extract relevant info from the event handler.

```
class VideoCaptureView extends Component {
  onVideoPause = event => {
    //can't access event.currentTarget.currentTime
  };
  render() {
    <VideoPlayer url={videoUrl} onPause={this.onVideoPause} />;
  }
}

```