### PR TITLE
Fix Vimeo link validation.

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -5,7 +5,7 @@ import createSinglePlayer from '../singlePlayer'
 
 const SDK_URL = 'https://player.vimeo.com/api/player.js'
 const SDK_GLOBAL = 'Vimeo'
-const MATCH_URL = /(?:www\.|player\.)?vimeo.com\/(?:(?:channels|ondemand)\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|album\/(\d+)\/video\/|video\/|)(\d+)(?:$|\/|\?)/
+const MATCH_URL = /(?:www\.|player\.)?vimeo.com\//
 
 export class Vimeo extends Component {
   static displayName = 'Vimeo'

--- a/test/specs/ReactPlayer.js
+++ b/test/specs/ReactPlayer.js
@@ -11,7 +11,7 @@ const TEST_URLS = [
   {
     name: 'FilePlayer',
     url: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.ogv',
-    switchTo: 'http://www.sample-videos.com/audio/mp3/crowd-cheering.mp3',
+    switchTo: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4',
     error: 'http://example.com/error.ogv',
     onSeek: true
   },


### PR DESCRIPTION
There is an issue, when using player with some of Vimeo links. 

Sharing this video https://vimeo.com/249675407 using Vimeo's share button generates link as follows: https://vimeo.com/yannickcerrutti/annecydroneinmotion. Such link isn't treated as Vimeo's, but it should be. I propose simplifying regex - there is no need for such complexity due to of possible variations of links. 

I've also spotted corrupted file link which I've replaced with working one so that test would pass again.