### PR TITLE
YouTube Videos Not Forwarding `end` Param

### DIFF
--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -37,6 +37,7 @@ export class YouTube extends Component {
           mute: muted ? 1 : 0,
           controls: controls ? 1 : 0,
           start: parseStartTime(url),
+          end: parseEndTime(url),
           origin: window.location.origin,
           playsinline: playsinline,
           ...playerVars


### PR DESCRIPTION
### GitHub Issue URL

> #419

### Description

  - YouTube videos not forwarding `end` param
