### PR TITLE
Check null before accessing FilePlayer properties

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -160,12 +160,15 @@ export class FilePlayer extends Component {
     this.player.playbackRate = rate
   }
   getDuration () {
+    if (!this.player) return null
     return this.player.duration
   }
   getCurrentTime () {
+    if (!this.player) return null
     return this.player.currentTime
   }
   getSecondsLoaded () {
+    if (!this.player) return null
     const { buffered } = this.player
     if (buffered.length === 0) {
       return 0


### PR DESCRIPTION
This is a fix for https://github.com/CookPete/react-player/issues/463
Adding null check here solves the problem 