### PR TITLE
Fix: signal multiple sources change to the browser

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 
 import { propTypes, defaultProps } from './props'
+import { isEqual } from './utils'
 
 const SEEK_ON_PLAY_EXPIRY = 5000
 
@@ -32,7 +33,7 @@ export default class Player extends Component {
   componentWillReceiveProps (nextProps) {
     // Invoke player methods based on incoming props
     const { url, playing, volume, muted, playbackRate } = this.props
-    if (url !== nextProps.url) {
+    if (!isEqual(url, nextProps.url)) {
       if (this.isLoading) {
         console.warn(`ReactPlayer: the attempt to load ${nextProps.url} is being deferred until the player has loaded`)
         this.loadOnReady = nextProps.url

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -120,14 +120,11 @@ export class FilePlayer extends Component {
     }
 
     if (url instanceof Array) {
-      // Whenever working with multiple sources (array), it seems
-      // to be required to signal manually the browser of the source change.
-      // Just replacing children source dom nodes is not enough
-      try {
-        this.player.load()
-      } catch (e) {
-        // ignore
-      }
+      // When setting new urls (<source>) on an already loaded video,
+      // HTMLMediaElement.load() is needed to reset the media element
+      // and restart the media resource. Just replacing children source
+      // dom nodes is not enough
+      this.player.load()
     } else if (isMediaStream(url)) {
       try {
         this.player.srcObject = url

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -119,7 +119,7 @@ export class FilePlayer extends Component {
       })
     }
 
-    if (url instanceof Array ) {
+    if (url instanceof Array) {
       // Whenever working with multiple sources (array), it seems
       // to be required to signal manually the browser of the source change.
       // Just replacing children source dom nodes is not enough

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -124,7 +124,7 @@ export class FilePlayer extends Component {
       // to be required to signal manually the browser of the source change.
       // Just replacing children source dom nodes is not enough
       try {
-        this.player.srcObject = null
+        this.player.load()
       } catch (e) {
         // ignore
       }

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -118,7 +118,17 @@ export class FilePlayer extends Component {
         this.dash.getDebug().setLogToBrowserConsole(false)
       })
     }
-    if (isMediaStream(url)) {
+
+    if (url instanceof Array ) {
+      // Whenever working with multiple sources (array), it seems
+      // to be required to signal manually the browser of the source change.
+      // Just replacing children source dom nodes is not enough
+      try {
+        this.player.srcObject = null
+      } catch (e) {
+        // ignore
+      }
+    } else if (isMediaStream(url)) {
       try {
         this.player.srcObject = url
       } catch (e) {


### PR DESCRIPTION
Hey @CookPete 

I'm building a PWA where I need to be able to load videos from a list. I'm using multiple sources mode (webm/mp4 and multilingual tracks to set videos).

Unfortunately, if the initial loading works, subsequent updates of the sources does not trigger a reload (although the DOM  shows updated `<source> and <track>`). See my initial ticket : #481. To illustrate the problem switch multiple sources on this demo https://soluble.io/react-player/demo/

I thought initially to change the react keys of the sources in `FilePlayer.js`:

```js
 renderSourceElement = (source, index) => {
    /* This was a first attempt to fix https://github.com/CookPete/react-player/issues/481
     * Unfortunately it's not working
    */
    if (typeof source === 'string') {
      return <source key={`${source}-${index}`} src={source} />
    }
    return <source key={`${source.src}-${index}`} {...source} />
    
```

But it's not working.

My solution was to signal / trigger the change by setting `srcObject = null` when there's a source change. Both Firefox 61 and Chrome 68 seems to work (using ubuntu 18.04). To be sure it does not produce errors on others browsers, it's encloded in a try/catch...

Please let me know if it looks good to you. 

Thanks for the great work.

