### PR TITLE
Typings - label in TrackProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ export interface TrackProps {
   kind: string;
   src: string;
   srcLang: string;
+  label: string;
   default?: boolean;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,6 @@ export interface TrackProps {
   kind: string;
   src: string;
   srcLang: string;
-  label: string;
   default?: boolean;
 }
 


### PR DESCRIPTION
Added typing for `label` in `TrackProps` -  A user-readable title of the text track which is used by the browser when listing available text tracks.