### PR TITLE
fix: fix onProgress callback not firing during iOS live streams

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -168,7 +168,13 @@ export class FilePlayer extends Component {
   }
   getDuration () {
     if (!this.player) return null
-    return this.player.duration
+    const { duration } = this.player
+    // on iOS, live streams return Infinity for the duration
+    // so instead we use the end of the seekable timerange
+    if (duration === Infinity) {
+      return this.player.seekable.end(0)
+    }
+    return duration
   }
   getCurrentTime () {
     if (!this.player) return null

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -171,7 +171,7 @@ export class FilePlayer extends Component {
     const { duration } = this.player
     // on iOS, live streams return Infinity for the duration
     // so instead we use the end of the seekable timerange
-    if (duration === Infinity) {
+    if (duration === Infinity && this.player.seekable.length > 0) {
       return this.player.seekable.end(this.player.seekable.length - 1)
     }
     return duration

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -172,7 +172,7 @@ export class FilePlayer extends Component {
     // on iOS, live streams return Infinity for the duration
     // so instead we use the end of the seekable timerange
     if (duration === Infinity) {
-      return this.player.seekable.end(0)
+      return this.player.seekable.end(this.player.seekable.length - 1)
     }
     return duration
   }

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -168,11 +168,11 @@ export class FilePlayer extends Component {
   }
   getDuration () {
     if (!this.player) return null
-    const { duration } = this.player
+    const { duration, seekable } = this.player
     // on iOS, live streams return Infinity for the duration
     // so instead we use the end of the seekable timerange
-    if (duration === Infinity && this.player.seekable.length > 0) {
-      return this.player.seekable.end(this.player.seekable.length - 1)
+    if (duration === Infinity && seekable.length > 0) {
+      return seekable.end(seekable.length - 1)
     }
     return duration
   }


### PR DESCRIPTION
I noticed that the `onProgress` callback only gets fired once during live streams on iOS. This is because, on iOS, `player.duration` returns `Infinity` for live streams. Since it always returns `Infinity`, the progress timeout short-circuits and so the callback stops firing altogether.

I have recently had to fix this issue in a few other places, and I have found that using `player.seekable.end(0)` works great as an alternative. It returns the same thing as `player.duration`, but works on iOS as well.

In order to minimize the potential impact of this change, I explicitly check for `Infinity` and only then do I return `player.seekable.end(0)`. Otherwise I continue to return value of the `duration` property.

Let me know if you need me to me make any updates!