### PR TITLE
add absent methods signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,6 +101,8 @@ export interface ReactPlayerProps {
 
 export default class ReactPlayer extends React.Component<ReactPlayerProps, any> {
   static canPlay(url: string): boolean;
+  static addCustomPlayer(player: ReactPlayer): void;
+  static removeCustomPlayers(): void;
   seekTo(fraction: number): void;
   getCurrentTime(): number;
   getDuration(): number;


### PR DESCRIPTION
Someone forgot to add typings for methods `addCustomPlayer` and `removeCustomPlayers`.