### PR TITLE
Vimeo url used in Preload is not available any more

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -20,7 +20,7 @@ const PRELOAD_PLAYERS = [
   {
     Player: Vimeo,
     configKey: 'vimeo',
-    url: 'https://vimeo.com/261464690'
+    url: 'https://vimeo.com/300970506'
   },
   {
     Player: DailyMotion,

--- a/src/preload.js
+++ b/src/preload.js
@@ -20,7 +20,7 @@ const PRELOAD_PLAYERS = [
   {
     Player: Vimeo,
     configKey: 'vimeo',
-    url: 'https://vimeo.com/127250231'
+    url: 'https://vimeo.com/261464690'
   },
   {
     Player: DailyMotion,


### PR DESCRIPTION
Hi,

The player is not able to load Vimeo video, as the vimeo url used in preload is not available (404).
A quick fix was
replace vimeo url, as https://vimeo.com/127250231 is not available any more.
The new url is just a random url for a short video. it can be replaced by anything else.

best,
