### PR TITLE
Accept youtube.com/playlist?list= URLs

### DIFF
--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -6,7 +6,7 @@ import createSinglePlayer from '../singlePlayer'
 const SDK_URL = 'https://www.youtube.com/iframe_api'
 const SDK_GLOBAL = 'YT'
 const SDK_GLOBAL_READY = 'onYouTubeIframeAPIReady'
-const MATCH_URL = /(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})/
+const MATCH_URL = /(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})|youtube\.com\/playlist\?list=/
 const MATCH_PLAYLIST = /list=([a-zA-Z0-9_-]+)/
 
 function parsePlaylist (url) {


### PR DESCRIPTION
This will allow **react-player** to play URLs like https://www.youtube.com/playlist?list=PLDEcUiPhzbjI217qs5KgMvbvx6-fgY_Al. I'm not sure on the policy here ― should it play only those links that are "supposed" to be played (those that are "shareable" and have `v=` parameter) vs should it play anything that was dropped on it if it can (even if the user copied "wrong" playlist URL)?