### PR TITLE
Add "playsinline" attribute to avoid iOS automatic full-screen

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -262,6 +262,7 @@ export class FilePlayer extends Component {
         controls={controls}
         muted={muted}
         loop={loop}
+        playsinline=""
         {...config.file.attributes}>
         {url instanceof Array &&
           url.map(this.renderSourceElement)


### PR DESCRIPTION
By default IOS play videos in full-screen mode, this commit disable this feature to improve consistency between browsers.

More information here: https://webkit.org/blog/6784/new-video-policies-for-ios/