### PR TITLE
Do not use vimeo API to play vimeo hosted video files.

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -6,7 +6,7 @@ import createSinglePlayer from '../singlePlayer'
 const SDK_URL = 'https://player.vimeo.com/api/player.js'
 const SDK_GLOBAL = 'Vimeo'
 const MATCH_URL = /vimeo\.com\/.+/
-const MATCH_FILE_URL = /vimeo\.com\/external\/.+\.[mp4|m3u]/
+const MATCH_FILE_URL = /vimeo\.com\/external\/[0-9]+\..+/
 
 export class Vimeo extends Component {
   static displayName = 'Vimeo'

--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -6,7 +6,7 @@ import createSinglePlayer from '../singlePlayer'
 const SDK_URL = 'https://player.vimeo.com/api/player.js'
 const SDK_GLOBAL = 'Vimeo'
 const MATCH_URL = /vimeo\.com\/.+/
-const MATCH_FILE_URL = /vimeo\.com\/external\/.+\.mp4/
+const MATCH_FILE_URL = /vimeo\.com\/external\/.+\.[mp4|m3u]/
 
 export class Vimeo extends Component {
   static displayName = 'Vimeo'

--- a/test/players/Vimeo.js
+++ b/test/players/Vimeo.js
@@ -16,6 +16,11 @@ const TEST_CONFIG = {
   }
 }
 
+test('canPlay', t => {
+  t.false(Vimeo.canPlay('https://player.vimeo.com/external/268931179.m3u8?s=4d7bec5817b90f9227891dd828e32deb91fa01e7'))
+  t.false(Vimeo.canPlay('https://player.vimeo.com/external/134290208.sd.mp4?s=9000cee9e39cb10a907c297ec36bcde452dfb9e5'))
+})
+
 testPlayerMethods(Vimeo, {
   play: 'play',
   pause: 'pause',


### PR DESCRIPTION
If you have a vimeo PRO account, you get direct urls for your videos. Unfortunately, react-player will try to play them with the vimeo player.

This was fixed for `mp4` files in this commit:
https://github.com/CookPete/react-player/commit/6f10f61a0657ae800b4d2116787efce2ce97f2dd

The issue is still there for `m3u` files though – e.g. 
`https://player.vimeo.com/external/268931179.m3u8?s=4d7bec5817b90f9227891dd828e32deb91fa01e7`.