### PR TITLE
FilePlayer: calls onPlay when "playing" events gets fired

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -68,7 +68,7 @@ export class FilePlayer extends Component {
   addListeners () {
     const { onReady, onPlay, onPause, onEnded, onError, playsinline, onEnablePIP } = this.props
     this.player.addEventListener('canplay', onReady)
-    this.player.addEventListener('play', onPlay)
+    this.player.addEventListener('playing', onPlay)
     this.player.addEventListener('pause', onPause)
     this.player.addEventListener('seeked', this.onSeek)
     this.player.addEventListener('ended', onEnded)
@@ -84,7 +84,7 @@ export class FilePlayer extends Component {
   removeListeners () {
     const { onReady, onPlay, onPause, onEnded, onError, onEnablePIP } = this.props
     this.player.removeEventListener('canplay', onReady)
-    this.player.removeEventListener('play', onPlay)
+    this.player.removeEventListener('playing', onPlay)
     this.player.removeEventListener('pause', onPause)
     this.player.removeEventListener('seeked', this.onSeek)
     this.player.removeEventListener('ended', onEnded)


### PR DESCRIPTION
According to the README onPlay gets called when media starts or
resumes playing after pausing or buffering.
The corresponding DOM event for that is "playing", not "play", see
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/playing_event
The "play" event indicates a change of "paused" or "autoplay" attr.