### PR TITLE
Soundcloud - fix autoplay delegation

### DIFF
--- a/src/players/SoundCloud.js
+++ b/src/players/SoundCloud.js
@@ -89,7 +89,7 @@ export class SoundCloud extends Component {
         src={`https://w.soundcloud.com/player/?url=${encodeURIComponent(this.props.url)}`}
         style={style}
         frameBorder={0}
-        allow={'autoplay'}
+        allow='autoplay'
       />
     )
   }

--- a/src/players/SoundCloud.js
+++ b/src/players/SoundCloud.js
@@ -89,6 +89,7 @@ export class SoundCloud extends Component {
         src={`https://w.soundcloud.com/player/?url=${encodeURIComponent(this.props.url)}`}
         style={style}
         frameBorder={0}
+        allow={'autoplay'}
       />
     )
   }

--- a/test/players/SoundCloud.js
+++ b/test/players/SoundCloud.js
@@ -87,6 +87,7 @@ test('render()', t => {
       src='https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fmiami-nights-1984%2Faccelerated'
       style={style}
       frameBorder={0}
+      allow='autoplay'
     />
   ))
 })


### PR DESCRIPTION
Since the Soundcloud Player is loaded via an iframe, there are instances when that player will not be allowed to play in Chrome, even after a user has interacted with the parent document. The parent receives the autoplay permission but it's never delegated to the iframe because it currently does not have a "feature policy" attribute. 

More information here: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#iframe 

This PR adds that attribute for autoplay and updates the accompanying test. 