### PR TITLE
Add on error callback to wistia player

### DIFF
--- a/src/players/Wistia.js
+++ b/src/players/Wistia.js
@@ -17,7 +17,7 @@ export class Wistia extends Component {
     return url && url.match(MATCH_URL)[1]
   }
   load (url) {
-    const { playing, muted, controls, onReady, onPlay, onPause, onSeek, onEnded, config } = this.props
+    const { playing, muted, controls, onReady, onPlay, onPause, onSeek, onEnded, config, onError } = this.props
     getSDK(SDK_URL, SDK_GLOBAL).then(() => {
       window._wq = window._wq || []
       window._wq.push({
@@ -38,7 +38,7 @@ export class Wistia extends Component {
           onReady()
         }
       })
-    })
+    }, onError)
   }
   play () {
     this.callPlayer('play')


### PR DESCRIPTION
The wistia player was missing onError callback. I added it in the same fashion as how it's in Youtube player. 