### PR TITLE
align typings for seekTo method with code

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -113,7 +113,7 @@ export default class ReactPlayer extends React.Component<ReactPlayerProps, any> 
   static canEnablePIP(url: string): boolean;
   static addCustomPlayer(player: ReactPlayer): void;
   static removeCustomPlayers(): void;
-  seekTo(fraction: number): void;
+  seekTo(amount: number, type?: 'seconds' | 'fraction'): void;
   getCurrentTime(): number;
   getDuration(): number;
   getInternalPlayer(key?: string): Object;


### PR DESCRIPTION
The docs mention that this is how the types ought to be.