### PR TITLE
Catches error on Vimeo play()

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -64,7 +64,10 @@ export class Vimeo extends Component {
     })
   }
   play () {
-    this.callPlayer('play')
+    const promise = this.callPlayer('play')
+    if (promise) {
+      promise.catch(this.props.onError)
+    }
   }
   pause () {
     this.callPlayer('pause')


### PR DESCRIPTION
Getting an error on Rollbar:
`PlayInterrupted: The play() request was interrupted by a call to pause()`
in the Vimeo player.

Saw that there was a similar problem [here](https://github.com/CookPete/react-player/issues/200) and thought I'd go ahead and submit a PR since it's the exact same error.

I've muted this error for now in my project since I know nothing is wrong.