### PR TITLE
Feature added option for dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,24 @@ Key | Options
 `mixcloud` | `options`: Override the [default player options](https://www.mixcloud.com/developers/widget/#methods)
 `dailymotion` | `params`: Override the [default player vars](https://developer.dailymotion.com/player#player-parameters)<br />`preload`: Used for [preloading](#preloading)
 `twitch` | `options`: Override the [default player options](https://dev.twitch.tv/docs/embed)
-`file` | `attributes`: Apply [element attributes](https://developer.mozilla.org/en/docs/Web/HTML/Element/video#Attributes)<br />`forceVideo`: Always render a `<video>` element<br />`forceAudio`: Always render an `<audio>` element<br />`forceHLS`: Use [hls.js](https://github.com/video-dev/hls.js) for HLS streams<br />`forceDASH`: Always use [dash.js](https://github.com/Dash-Industry-Forum/dash.js) for DASH streams<br />`hlsOptions`: Override the [default `hls.js` options](https://github.com/video-dev/hls.js/blob/master/docs/API.md#fine-tuning)<br />`hlsVersion`: Override the [`hls.js`](https://github.com/video-dev/hls.js) version loaded from [`cdnjs`](https://cdnjs.com/libraries/hls.js), default: `0.10.1`<br />`dashVersion`: Override the [`dash.js`](https://github.com/Dash-Industry-Forum/dash.js) version loaded from [`cdnjs`](https://cdnjs.com/libraries/dashjs), default: `2.9.2`
+`file` | `attributes`: Apply [element attributes](https://developer.mozilla.org/en/docs/Web/HTML/Element/video#Attributes)<br />`forceVideo`: Always render a `<video>` element<br />`forceAudio`: Always render an `<audio>` element<br />`forceHLS`: Use [hls.js](https://github.com/video-dev/hls.js) for HLS streams<br />`forceDASH`: Always use [dash.js](https://github.com/Dash-Industry-Forum/dash.js) for DASH streams<br />`hlsOptions`: Override the [default `hls.js` options](https://github.com/video-dev/hls.js/blob/master/docs/API.md#fine-tuning)<br />`dashOptions`: Override the [default `dash.js` options](http://cdn.dashjs.org/latest/jsdoc/module-MediaPlayer.html)<br />`hlsVersion`: Override the [`hls.js`](https://github.com/video-dev/hls.js) version loaded from [`cdnjs`](https://cdnjs.com/libraries/hls.js), default: `0.10.1`<br />`dashVersion`: Override the [`dash.js`](https://github.com/Dash-Industry-Forum/dash.js) version loaded from [`cdnjs`](https://cdnjs.com/libraries/dashjs), default: `2.9.2`
+
+Support for dash methods [dash methods](http://cdn.dashjs.org/latest/jsdoc/module-MediaPlayer.html) with example:
+
+```jsx
+<ReactPlayer
+  config={
+    file: {
+        dashOptions: {
+            getXHRWithCredentialsForType: {
+                params: ['GET'],
+                callback: (e) => console.log(e)
+            }
+        }
+    }
+  }
+/>
+```
 
 ##### Preloading
 

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -135,7 +135,7 @@ export class FilePlayer extends Component {
     }
     if (this.shouldUseDASH(url)) {
       getSDK(DASH_SDK_URL.replace('VERSION', dashVersion), DASH_GLOBAL).then(dashjs => {
-        let dashConfig = this.props.config.file.dashOptions
+        let dashConfig = this.props.config.file.dashOptions || {}
         let results = {}
         this.dash = dashjs.MediaPlayer().create()
         this.dash.initialize(this.player, url, this.props.playing)

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -135,9 +135,22 @@ export class FilePlayer extends Component {
     }
     if (this.shouldUseDASH(url)) {
       getSDK(DASH_SDK_URL.replace('VERSION', dashVersion), DASH_GLOBAL).then(dashjs => {
+        let dashConfig = this.props.config.file.dashOptions
+        let results = null
         this.dash = dashjs.MediaPlayer().create()
         this.dash.initialize(this.player, url, this.props.playing)
-        this.dash.getDebug().setLogToBrowserConsole(false)
+        this.dash.getDebug().setLogToBrowserConsole(true)
+        Object.keys(dashConfig).map(x => {
+          if (dashConfig[x].params) {
+            results = this.dash[x](...dashConfig[x].params)
+          } else {
+            results = this.dash[x]()
+          }
+
+          if (dashConfig[x].callback) {
+            dashConfig[x].callback(results)
+          }
+        })
       })
     }
 

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -139,7 +139,7 @@ export class FilePlayer extends Component {
         let results = null
         this.dash = dashjs.MediaPlayer().create()
         this.dash.initialize(this.player, url, this.props.playing)
-        this.dash.getDebug().setLogToBrowserConsole(true)
+        this.dash.getDebug().setLogToBrowserConsole(false)
         Object.keys(dashConfig).map(x => {
           if (dashConfig[x].params) {
             results = this.dash[x](...dashConfig[x].params)

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -136,7 +136,7 @@ export class FilePlayer extends Component {
     if (this.shouldUseDASH(url)) {
       getSDK(DASH_SDK_URL.replace('VERSION', dashVersion), DASH_GLOBAL).then(dashjs => {
         let dashConfig = this.props.config.file.dashOptions
-        let results = null
+        let results = {}
         this.dash = dashjs.MediaPlayer().create()
         this.dash.initialize(this.player, url, this.props.playing)
         this.dash.getDebug().setLogToBrowserConsole(false)


### PR DESCRIPTION
#### Current Behavior
Well, Dash.js is becoming more and more popular these days we need to enhance some functionality to explore dash through this player.
Currently in filePlayer does support to add custom methods for hlsOptions, but for a dash player, there isn't have any available props to access another method of dash.js. 
The issue was I needed to send cookies while requesting mpd file but the player isn't have enabled a required method for the dash.

#### Expected Behavior
So for access to this method, we can add dashOptions as hlsOptions, something like this.
```jsx
<ReactPlayer
  config={
    file: {
        dashOptions: {
            getXHRWithCredentialsForType: {
                params: ['GET'],
                callback: (e) => console.log(e)
            }
        }
    }
  }
/>
```
 

#### Steps to Reproduce
- This issue can be resolved with a just small change in FilePlayer.js 
- Need to update method for DashPlayer. After initialization of player, we can add a function which will call given function with given params(optional) and pass the response back to react-player through callback(optional) prop.
