### PR TITLE
Vimeo wrapper div should not have a background color.

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -108,8 +108,7 @@ export class Vimeo extends Component {
     const style = {
       width: '100%',
       height: '100%',
-      overflow: 'hidden',
-      backgroundColor: 'black'
+      overflow: 'hidden'
     }
     return (
       <div

--- a/test/players/Vimeo.js
+++ b/test/players/Vimeo.js
@@ -65,8 +65,7 @@ test('render()', t => {
   const style = {
     width: '100%',
     height: '100%',
-    overflow: 'hidden',
-    backgroundColor: 'black'
+    overflow: 'hidden'
   }
   t.true(wrapper.contains(
     <div key={TEST_URL} style={style} />


### PR DESCRIPTION
Sometimes a responsive video will have 1px on the side or bottom where this black poked through.