### PR TITLE
Add typedef support for MediaStream url source

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,7 @@ export interface Config {
 }
 
 export interface ReactPlayerProps {
-  url?: string | string[] | SourceProps[];
+  url?: string | string[] | SourceProps[] | MediaStream;
   playing?: boolean;
   loop?: boolean;
   controls?: boolean;


### PR DESCRIPTION
React-player supports MediaStream input as per documentation suggest, but type definition is missing.