### PR TITLE
Refactor lifecycle method componentWillUpdate to componentDidUpdate

### DIFF
--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -51,7 +51,7 @@ export default class ReactPlayer extends Component {
   shouldComponentUpdate (nextProps, nextState) {
     return !isEqual(this.props, nextProps) || !isEqual(this.state, nextState)
   }
-  componentDidUpdate(prevProps) {
+  componentDidUpdate (prevProps) {
     const { light } = prevProps
     this.config = getConfig(this.props, defaultProps)
     if (!light && this.props.light) {

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -51,13 +51,13 @@ export default class ReactPlayer extends Component {
   shouldComponentUpdate (nextProps, nextState) {
     return !isEqual(this.props, nextProps) || !isEqual(this.state, nextState)
   }
-  componentWillUpdate (nextProps) {
-    const { light } = this.props
-    this.config = getConfig(nextProps, defaultProps)
-    if (!light && nextProps.light) {
+  componentDidUpdate(prevProps) {
+    const { light } = prevProps
+    this.config = getConfig(this.props, defaultProps)
+    if (!light && this.props.light) {
       this.setState({ showPreview: true })
     }
-    if (light && !nextProps.light) {
+    if (light && !this.props.light) {
       this.setState({ showPreview: false })
     }
   }

--- a/src/singlePlayer.js
+++ b/src/singlePlayer.js
@@ -17,8 +17,8 @@ export default function createSinglePlayer (activePlayer) {
     shouldComponentUpdate (nextProps) {
       return !isEqual(this.props, nextProps)
     }
-    componentWillUpdate (nextProps) {
-      this.config = getConfig(nextProps, defaultProps)
+    componentDidUpdate () {
+      this.config = getConfig(this.props, defaultProps)
     }
     getDuration = () => {
       if (!this.player) return null


### PR DESCRIPTION
Rewrote the lifecycle method componentWillUpdate as componentDidUpdate. Tried to keep the changes as minimal as possible.  Newer versions of React emit a console.log warning componentWillUpdate deprecation.