### PR TITLE
Add PIP support for Safari

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -39,7 +39,9 @@ function canPlay (url) {
 
 function supportsWebKitPresentationMode (video) {
   if (!video) video = document.createElement('video')
-  return video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === 'function'
+  // Check if Safari supports PiP, and is not on mobile (other than iPad)
+  // iPhone safari appears to "support" PiP through the check, however PiP does not function
+  return video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === 'function' && !/iPhone|iPod/.test(navigator.userAgent)
 }
 
 function canEnablePIP (url) {

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -231,7 +231,7 @@ export class FilePlayer extends Component {
   enablePIP () {
     if (this.player.requestPictureInPicture && document.pictureInPictureElement !== this.player) {
       this.player.requestPictureInPicture()
-    } else if (supportsWebKitPresentationMode(this.player)) {
+    } else if (supportsWebKitPresentationMode(this.player) && this.player.webkitPresentationMode !== 'picture-in-picture') {
       this.player.webkitSetPresentationMode('picture-in-picture')
     }
   }
@@ -239,7 +239,7 @@ export class FilePlayer extends Component {
   disablePIP () {
     if (document.exitPictureInPicture && document.pictureInPictureElement === this.player) {
       document.exitPictureInPicture()
-    } else if (supportsWebKitPresentationMode(this.player)) {
+    } else if (supportsWebKitPresentationMode(this.player) && this.player.webkitPresentationMode !== 'inline') {
       this.player.webkitSetPresentationMode('inline')
     }
   }

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -122,8 +122,8 @@ export class FilePlayer extends Component {
   }
 
   onPresentationModeChange = e => {
-    const { webkitPresentationMode } = this.player
     if (this.player && supportsWebKitPresentationMode(this.player)) {
+      const { webkitPresentationMode } = this.player
       if (webkitPresentationMode === 'picture-in-picture') {
         this.onEnablePIP(e)
       } else if (webkitPresentationMode === 'inline') {


### PR DESCRIPTION
Safari supports PIP and has some benefits over that in Chrome for macOS (ability to use over multiple fullscreen windows, etc.). This PR makes the changes required to support Safari PIP mode.

**Note**
In the current Safari release (13), the `onDisablePIP` is run twice when exiting PIP. This is a bug with Safari has been fixed in the [latest Tech preview](https://webkit.org/blog/9526/release-notes-for-safari-technology-preview-91/).