### PR TITLE
Properly delete SDK requests

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -88,7 +88,7 @@ export function getSDK (url, sdkGlobal, sdkReady = null, isLoaded = () => true, 
         // Loading the SDK failed – reject all requests and
         // reset the array of requests for this SDK
         requests[url].forEach(request => request.reject(err))
-        requests[url] = []
+        requests[url] = null
       } else if (!sdkReady) {
         onLoaded(window[sdkGlobal])
       }

--- a/test/utils/getSDK.js
+++ b/test/utils/getSDK.js
@@ -11,7 +11,7 @@ test.beforeEach(t => {
   window.SDKReady = null
 })
 
-test('loads script', async t => {
+test.serial('loads script', async t => {
   const loadScriptOverride = sinon.fake(async (url, cb) => {
     await delay(100)
     window.SDK = 'sdk'
@@ -22,7 +22,7 @@ test('loads script', async t => {
   t.true(loadScriptOverride.calledOnce)
 })
 
-test('throws on error', async t => {
+test.serial('throws on error', async t => {
   const loadScriptOverride = sinon.fake(async (url, cb) => {
     await delay(100)
     cb(new Error('Load error'))
@@ -31,7 +31,7 @@ test('throws on error', async t => {
   t.true(loadScriptOverride.calledOnce)
 })
 
-test.skip('does not fetch again when loaded', async t => {
+test.serial('does not fetch again when loaded', async t => {
   const loadScriptOverride = sinon.fake()
   window.SDK = 'sdk'
   const sdk = await getSDK('http://example.com/def.js', 'SDK', undefined, undefined, loadScriptOverride)
@@ -39,7 +39,7 @@ test.skip('does not fetch again when loaded', async t => {
   t.true(loadScriptOverride.notCalled)
 })
 
-test.skip('does not fetch again when loading', async t => {
+test.serial('does not fetch again when loading', async t => {
   const loadScriptOverride = sinon.fake(async (url, cb) => {
     await delay(100)
     window.SDK = 'sdk'
@@ -54,7 +54,7 @@ test.skip('does not fetch again when loading', async t => {
   t.true(loadScriptOverride.calledOnce)
 })
 
-test.skip('waits for sdkReady callback', async t => {
+test.serial('waits for sdkReady callback', async t => {
   const loadScriptOverride = sinon.fake(async (url, cb) => {
     cb()
     await delay(100)
@@ -66,7 +66,7 @@ test.skip('waits for sdkReady callback', async t => {
   t.true(loadScriptOverride.calledOnce)
 })
 
-test.skip('multiple sdkReady callbacks', async t => {
+test.serial('multiple sdkReady callbacks', async t => {
   const loadScriptOverride = sinon.fake(async (url, cb) => {
     cb()
     await delay(100)

--- a/test/utils/getSDK.js
+++ b/test/utils/getSDK.js
@@ -54,6 +54,23 @@ test.serial('does not fetch again when loading', async t => {
   t.true(loadScriptOverride.calledOnce)
 })
 
+test.serial('does fetch again after fetch error', async t => {
+  const loadScriptOverrideError = sinon.fake(async (url, cb) => {
+    await delay(100)
+    cb(new Error('Load error'))
+  })
+  const loadScriptOverride = sinon.fake(async (url, cb) => {
+    await delay(100)
+    window.SDK = 'sdk'
+    cb()
+  })
+  await t.throwsAsync(getSDK('http://example.com/pqr.js', 'SDK', undefined, undefined, loadScriptOverrideError))
+  const sdk = await getSDK('http://example.com/pqr.js', 'SDK', undefined, undefined, loadScriptOverride)
+  t.is(sdk, 'sdk')
+  t.true(loadScriptOverrideError.calledOnce)
+  t.true(loadScriptOverride.calledOnce)
+})
+
 test.serial('waits for sdkReady callback', async t => {
   const loadScriptOverride = sinon.fake(async (url, cb) => {
     cb()


### PR DESCRIPTION
The changes of #711 don't have an effect as `requests[url]` is set to an empty array after a failed fetch which evaluates to `true` for all following fetches. It has to be set to something evaluating to `false` instead. I added a test for the scenario.

Additionally, I activated the other getSDK tests. As getSDK() uses global variables, the tests have to be serial.