### PR TITLE
Support to set the custom facebook version

### DIFF
--- a/src/players/Facebook.js
+++ b/src/players/Facebook.js
@@ -25,7 +25,7 @@ export class Facebook extends Component {
       FB.init({
         appId: this.props.config.facebook.appId,
         xfbml: true,
-        version: this.props.config.facebook.version,
+        version: this.props.config.facebook.version
       })
       FB.Event.subscribe('xfbml.render', msg => {
         // Here we know the SDK has loaded, even if onReady/onPlay

--- a/src/players/Facebook.js
+++ b/src/players/Facebook.js
@@ -25,7 +25,7 @@ export class Facebook extends Component {
       FB.init({
         appId: this.props.config.facebook.appId,
         xfbml: true,
-        version: 'v2.5'
+        version: this.props.config.facebook.version,
       })
       FB.Event.subscribe('xfbml.render', msg => {
         // Here we know the SDK has loaded, even if onReady/onPlay

--- a/src/props.js
+++ b/src/props.js
@@ -34,7 +34,8 @@ export const propTypes = {
       preload: bool
     }),
     facebook: shape({
-      appId: string
+      appId: string,
+      version: string
     }),
     dailymotion: shape({
       params: object,
@@ -120,6 +121,7 @@ export const defaultProps = {
     },
     facebook: {
       appId: '1309697205772819'
+      version: 'v2.5'
     },
     dailymotion: {
       params: {

--- a/src/props.js
+++ b/src/props.js
@@ -120,8 +120,8 @@ export const defaultProps = {
       preload: false
     },
     facebook: {
-      appId: '1309697205772819'
-      version: 'v2.5'
+      appId: '1309697205772819',
+      version: 'v3.3'
     },
     dailymotion: {
       params: {


### PR DESCRIPTION
The new version of the facebook version is `v3.3`. I would like to have a new config to set the facebook version. In my website, `react-player` will overwrite my facebook version. As a result, I can not use facebook login in my website.