### PR TITLE
Add showPreview() method to ReactPlayer typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -118,4 +118,5 @@ export default class ReactPlayer extends React.Component<ReactPlayerProps, any> 
   getCurrentTime(): number;
   getDuration(): number;
   getInternalPlayer(key?: string): Object;
+  showPreview(): void;
 }


### PR DESCRIPTION
Just started using this component in one of my projects when I noticed TS errors when using the showPreview() method.
Turns out it's missing in the type definition for ReactPlayer class. This PR aims to fix this.