### PR TITLE
Add missing config tracks

### DIFF
--- a/src/props.js
+++ b/src/props.js
@@ -46,8 +46,7 @@ export const propTypes = {
     }),
     file: shape({
       attributes: object,
-      tracks: 
-      ,
+      tracks: array,
       forceVideo: bool,
       forceAudio: bool,
       forceHLS: bool,

--- a/src/props.js
+++ b/src/props.js
@@ -17,6 +17,8 @@ export const propTypes = {
   playsinline: bool,
   pip: bool,
   light: oneOfType([bool, string]),
+  tracks: array,
+  attributes: object,
   playIcon: node,
   wrapper: oneOfType([
     string,
@@ -44,7 +46,8 @@ export const propTypes = {
     }),
     file: shape({
       attributes: object,
-      tracks: array,
+      tracks: 
+      ,
       forceVideo: bool,
       forceAudio: bool,
       forceHLS: bool,

--- a/src/props.js
+++ b/src/props.js
@@ -98,6 +98,7 @@ export const defaultProps = {
   light: false,
   wrapper: 'div',  
   tracks: [],
+  attributes: {},
   config: {
     soundcloud: {
       options: {

--- a/src/props.js
+++ b/src/props.js
@@ -96,7 +96,8 @@ export const defaultProps = {
   playsinline: false,
   pip: false,
   light: false,
-  wrapper: 'div',
+  wrapper: 'div',  
+  tracks: [],
   config: {
     soundcloud: {
       options: {


### PR DESCRIPTION
The file player access the `tracks` and `attributes` with ```config.tracks.map```, and it fails, it they are not provided, since they are missing in the default Props.