### PR TITLE
Adds the missing default data for the selected player

### DIFF
--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -111,7 +111,7 @@ export default class ReactPlayer extends Component {
   getConfig = memoize((url, key) => {
     const { config } = this.props
     return merge.all([
-      defaultProps.config,      
+      defaultProps.config,
       defaultProps.config[key] || {},
       config,
       config[key] || {}

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -111,7 +111,8 @@ export default class ReactPlayer extends Component {
   getConfig = memoize((url, key) => {
     const { config } = this.props
     return merge.all([
-      defaultProps.config,
+      defaultProps.config,      
+      defaultProps.config[key],
       config,
       config[key] || {}
     ])

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -112,7 +112,7 @@ export default class ReactPlayer extends Component {
     const { config } = this.props
     return merge.all([
       defaultProps.config,      
-      defaultProps.config[key],
+      defaultProps.config[key] || {},
       config,
       config[key] || {}
     ])


### PR DESCRIPTION
This adds the default config to the config file, if a certain player is selected. 
If not and an empty config is provided, calls like config.tracks or config.attribuites fails.
Also the cdn loading fails, because the version is undefined because the default version is not supplied.