### PR TITLE
Fix ReactPlayer refs not being set

### DIFF
--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -42,7 +42,7 @@ export default class ReactPlayer extends Component {
     showPreview: !!this.props.light
   }
 
-  refs = {
+  elementRefs = {
     wrapper: wrapper => { this.wrapper = wrapper },
     player: player => { this.player = player }
   }
@@ -142,7 +142,7 @@ export default class ReactPlayer extends Component {
       <Player
         {...this.props}
         key={player.key}
-        ref={this.refs.player}
+        ref={this.elementRefs.player}
         config={config}
         activePlayer={player.lazyPlayer || player}
         onReady={this.handleReady}
@@ -155,7 +155,7 @@ export default class ReactPlayer extends Component {
     const { showPreview } = this.state
     const attributes = this.getAttributes(url)
     return (
-      <Wrapper ref={this.refs.wrapper} style={{ ...style, width, height }} {...attributes}>
+      <Wrapper ref={this.elementRefs.wrapper} style={{ ...style, width, height }} {...attributes}>
         <Suspense fallback={null}>
           {showPreview
             ? this.renderPreview(url)

--- a/test/ReactPlayer/instanceMethods.js
+++ b/test/ReactPlayer/instanceMethods.js
@@ -12,7 +12,7 @@ const COMMON_METHODS = ['getDuration', 'getCurrentTime', 'getSecondsLoaded', 'ge
 for (const method of COMMON_METHODS) {
   test(`${method}()`, t => {
     const instance = shallow(<ReactPlayer />).instance()
-    instance.refs.player({ [method]: () => 123 })
+    instance.elementRefs.player({ [method]: () => 123 })
     t.true(instance[method]() === 123)
   })
 
@@ -25,14 +25,14 @@ for (const method of COMMON_METHODS) {
 test('getInternalPlayer() - default', t => {
   const instance = shallow(<ReactPlayer />).instance()
   const getInternalPlayer = sinon.fake.returns('abc')
-  instance.refs.player({ getInternalPlayer })
+  instance.elementRefs.player({ getInternalPlayer })
   t.true(instance.getInternalPlayer() === 'abc')
   t.true(getInternalPlayer.calledOnceWith('player'))
 })
 
 test('seekTo()', t => {
   const instance = shallow(<ReactPlayer />).instance()
-  instance.refs.player({ seekTo: sinon.fake() })
+  instance.elementRefs.player({ seekTo: sinon.fake() })
   instance.seekTo(5)
   t.true(instance.player.seekTo.calledOnce)
   t.true(instance.player.seekTo.calledWith(5))
@@ -50,10 +50,10 @@ test('onReady()', t => {
   t.true(onReady.calledWith(instance))
 })
 
-test('refs', t => {
+test('elementRefs', t => {
   const instance = shallow(<ReactPlayer />).instance()
-  instance.refs.player('abc')
-  instance.refs.wrapper('def')
+  instance.elementRefs.player('abc')
+  instance.elementRefs.wrapper('def')
   t.true(instance.player === 'abc')
   t.true(instance.wrapper === 'def')
 })


### PR DESCRIPTION
This fixes an issue and where `player` and `wrapper` refs are not set correctly in `ReactPlayer`, causing instance methods to stop working. Tested with v2.0.0 and I think this version is the only one affected.


Introduced in 9c9a4d401f8238ddef5630e0b3727604d84e21ca.