### PR TITLE
Fix player refs not setting correctly.

### DIFF
--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -42,7 +42,7 @@ export default class ReactPlayer extends Component {
     showPreview: !!this.props.light
   }
 
-  refs = {
+  setRef = {
     wrapper: wrapper => { this.wrapper = wrapper },
     player: player => { this.player = player }
   }
@@ -142,7 +142,7 @@ export default class ReactPlayer extends Component {
       <Player
         {...this.props}
         key={player.key}
-        ref={this.refs.player}
+        ref={this.setRef.player}
         config={config}
         activePlayer={player.lazyPlayer || player}
         onReady={this.handleReady}
@@ -155,7 +155,7 @@ export default class ReactPlayer extends Component {
     const { showPreview } = this.state
     const attributes = this.getAttributes(url)
     return (
-      <Wrapper ref={this.refs.wrapper} style={{ ...style, width, height }} {...attributes}>
+      <Wrapper ref={this.setRef.wrapper} style={{ ...style, width, height }} {...attributes}>
         <Suspense fallback={null}>
           {showPreview
             ? this.renderPreview(url)

--- a/test/ReactPlayer/instanceMethods.js
+++ b/test/ReactPlayer/instanceMethods.js
@@ -12,7 +12,7 @@ const COMMON_METHODS = ['getDuration', 'getCurrentTime', 'getSecondsLoaded', 'ge
 for (const method of COMMON_METHODS) {
   test(`${method}()`, t => {
     const instance = shallow(<ReactPlayer />).instance()
-    instance.refs.player({ [method]: () => 123 })
+    instance.setRef.player({ [method]: () => 123 })
     t.true(instance[method]() === 123)
   })
 
@@ -25,14 +25,14 @@ for (const method of COMMON_METHODS) {
 test('getInternalPlayer() - default', t => {
   const instance = shallow(<ReactPlayer />).instance()
   const getInternalPlayer = sinon.fake.returns('abc')
-  instance.refs.player({ getInternalPlayer })
+  instance.setRef.player({ getInternalPlayer })
   t.true(instance.getInternalPlayer() === 'abc')
   t.true(getInternalPlayer.calledOnceWith('player'))
 })
 
 test('seekTo()', t => {
   const instance = shallow(<ReactPlayer />).instance()
-  instance.refs.player({ seekTo: sinon.fake() })
+  instance.setRef.player({ seekTo: sinon.fake() })
   instance.seekTo(5)
   t.true(instance.player.seekTo.calledOnce)
   t.true(instance.player.seekTo.calledWith(5))
@@ -50,10 +50,10 @@ test('onReady()', t => {
   t.true(onReady.calledWith(instance))
 })
 
-test('refs', t => {
+test('setRef', t => {
   const instance = shallow(<ReactPlayer />).instance()
-  instance.refs.player('abc')
-  instance.refs.wrapper('def')
+  instance.setRef.player('abc')
+  instance.setRef.wrapper('def')
   t.true(instance.player === 'abc')
   t.true(instance.wrapper === 'def')
 })


### PR DESCRIPTION
I described an issue I encountered here on the demo.
https://github.com/CookPete/react-player/issues/867

I then experienced this same problem in my own code, where `seekTo` wasn't working correctly. It turns out that the issue was actually far more widespread, and the ref just wasn't being set at all.

When I logged out the object in `ReactPlayer` that was called `refs`, which was meant to hold two functions to set refs in child components, it was an empty object. This appears to be a reserved keyword that is presumably used by react, as it was being overridden with an empty object. Simply changing the property name from `refs` to `setRef` resolved the issue, and seeking behavior (among other things) now work correctly.

In order to test: follow the steps in the issue I linked above, and notice the broken behavior. Then test the same behavior in this branch, and note it functioning correctly.