### PR TITLE
Destroy hls player on changing source. Unit test is included.

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -16,6 +16,7 @@ export default class FilePlayer extends Component {
   componentDidMount () {
     this.props.onMount && this.props.onMount(this)
     this.addListeners(this.player)
+    this.hls=null
     if (IOS) {
       this.player.load()
     }
@@ -32,6 +33,7 @@ export default class FilePlayer extends Component {
     this.removeListeners(this.player)
     if (this.hls) {
       this.hls.destroy()
+      this.hls=null
     }
   }
 
@@ -124,6 +126,9 @@ export default class FilePlayer extends Component {
     const { hlsVersion, hlsOptions, dashVersion } = this.props.config
     if (this.shouldUseHLS(url)) {
       getSDK(HLS_SDK_URL.replace('VERSION', hlsVersion), HLS_GLOBAL).then(Hls => {
+        if (this.hls != null ) {
+          this.hls.destroy()
+        }
         this.hls = new Hls(hlsOptions)
         this.hls.on(Hls.Events.ERROR, (e, data) => {
           this.props.onError(e, data, this.hls, Hls)

--- a/test/players/FilePlayer.js
+++ b/test/players/FilePlayer.js
@@ -375,3 +375,20 @@ test('auto width/height', t => {
     </video>
   ))
 })
+
+test('load - hls. Change source', async t => {
+  class Hls {
+    static Events = { ERROR: 'ERROR' }
+    on = () => null
+    loadSource = () => null
+    attachMedia = () => t.pass()
+  }
+  const url = 'file.m3u8'
+  const getSDK = sinon.stub(utils, 'getSDK').resolves(Hls)
+  const instance = shallow(<FilePlayer url={url} config={config} />).instance()
+  const destroy = sinon.fake()
+  instance.hls = { destroy }
+  await instance.load ( url )
+  t.true ( destroy.calledOnce )
+  getSDK.restore()  
+})


### PR DESCRIPTION
Current behaviour: On change source we creating new HLS player but the old one still exists and continue to download the manifest. If we switch 2-3 channels we have 2-3 working hls players and HLS errors begin.

Fix: We are destroying hls player instance before creating the new one. No more errors and additional traffic. Unit test was included. 