### PR TITLE
Match YouTube User Uploads

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -1,4 +1,4 @@
-export const MATCH_URL_YOUTUBE = /(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})|youtube\.com\/playlist\?list=/
+export const MATCH_URL_YOUTUBE = /(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})|youtube\.com\/playlist\?list=|youtube\.com\/user\/?/
 export const MATCH_URL_SOUNDCLOUD = /(?:soundcloud\.com|snd\.sc)\/[^.]+$/
 export const MATCH_URL_VIMEO = /vimeo\.com\/.+/
 export const MATCH_URL_FACEBOOK = /^https?:\/\/(www\.)?facebook\.com.*\/(video(s)?|watch|story)(\.php?|\/).+$/

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -7,6 +7,7 @@ const SDK_URL = 'https://www.youtube.com/iframe_api'
 const SDK_GLOBAL = 'YT'
 const SDK_GLOBAL_READY = 'onYouTubeIframeAPIReady'
 const MATCH_PLAYLIST = /list=([a-zA-Z0-9_-]+)/
+const MATCH_USER_UPLOADS = /user\/([a-zA-Z0-9_-]+)\/?/
 
 function parsePlaylist (url) {
   if (MATCH_PLAYLIST.test(url)) {
@@ -14,6 +15,12 @@ function parsePlaylist (url) {
     return {
       listType: 'playlist',
       list: playlistId
+    }
+  } else if (MATCH_USER_UPLOADS.test(url)) {
+    const [, username] = url.match(MATCH_USER_UPLOADS)
+    return {
+      listType: 'user_uploads',
+      list: username
     }
   }
   return {}
@@ -32,7 +39,7 @@ export default class YouTube extends Component {
     const { playerVars, embedOptions } = config
     const id = url && url.match(MATCH_URL_YOUTUBE)[1]
     if (isReady) {
-      if (MATCH_PLAYLIST.test(url)) {
+      if (MATCH_PLAYLIST.test(url) || MATCH_USER_UPLOADS.test(url)) {
         this.player.loadPlaylist(parsePlaylist(url))
         return
       }


### PR DESCRIPTION
Added ability to set URL to YouTube user profiles e.g. https://youtube.com/user/songstowearpantsto/
e.g. https://www.youtube.com/user/Rhaptapsody

If this URL pattern is matched, the player loads user's uploads as specified in the YouTube Player API. The playlist_type var is set to 'user_uploads' and the list is set to the username.