### PR TITLE
Destroy previous vidyard player before creating new one

### DIFF
--- a/src/players/Vidyard.js
+++ b/src/players/Vidyard.js
@@ -53,7 +53,6 @@ export default class Vidyard extends Component {
 
   stop () {
     window.VidyardV4.api.destroyPlayer(this.player)
-    delete this.player
   }
 
   seekTo (amount) {

--- a/src/players/Vidyard.js
+++ b/src/players/Vidyard.js
@@ -15,9 +15,12 @@ export default class Vidyard extends Component {
     this.props.onMount && this.props.onMount(this)
   }
 
-  load (url, isReady) {
+  load (url) {
     const { config, onError, onDuration } = this.props
     const id = url && url.match(MATCH_URL_VIDYARD)[1]
+    if (this.player) {
+      this.stop()
+    }
     getSDK(SDK_URL, SDK_GLOBAL, SDK_GLOBAL_READY).then(Vidyard => {
       if (!this.container) return
       Vidyard.api.addReadyListener((data, player) => {
@@ -50,6 +53,7 @@ export default class Vidyard extends Component {
 
   stop () {
     window.VidyardV4.api.destroyPlayer(this.player)
+    delete this.player
   }
 
   seekTo (amount) {


### PR DESCRIPTION
I had met a bug, that `react-player` calls several time `Vidyard.api.renderPlayer` if i switch video, which leads several `vidyard` players presence in same page.
Fix is to destroy previous player before creating new one.