### PR TITLE
add isMuted listener inside onProgress method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -114,6 +114,7 @@ export default class ReactPlayer extends React.Component<ReactPlayerProps, any> 
   seekTo(amount: number, type?: 'seconds' | 'fraction'): void;
   getCurrentTime(): number;
   getDuration(): number;
+  getIsMuted(): boolean;
   getInternalPlayer(key?: string): Object;
   showPreview(): void;
 }

--- a/src/Player.js
+++ b/src/Player.js
@@ -95,6 +95,11 @@ export default class Player extends Component {
     return this.player.getDuration()
   }
 
+  getIsMuted () {
+    if (!this.isReady) return null
+    return this.player.getIsMuted()
+  }
+
   getCurrentTime () {
     if (!this.isReady) return null
     return this.player.getCurrentTime()
@@ -115,10 +120,12 @@ export default class Player extends Component {
       const playedSeconds = this.getCurrentTime() || 0
       const loadedSeconds = this.getSecondsLoaded()
       const duration = this.getDuration()
+      const isMuted = this.getIsMuted()
       if (duration) {
         const progress = {
           playedSeconds,
-          played: playedSeconds / duration
+          played: playedSeconds / duration,
+          isMuted
         }
         if (loadedSeconds !== null) {
           progress.loadedSeconds = loadedSeconds

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -81,6 +81,11 @@ export default class ReactPlayer extends Component {
     return this.player.getDuration()
   }
 
+  getIsMuted () {
+    if (!this.player) return null
+    return this.player.getIsMuted()
+  }
+
   getCurrentTime = () => {
     if (!this.player) return null
     return this.player.getCurrentTime()

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -188,6 +188,10 @@ export default class FilePlayer extends Component {
     this.player.volume = fraction
   }
 
+  getIsMuted = () => {
+    return this.player.muted
+  }
+
   mute = () => {
     this.player.muted = true
   }

--- a/test/Player.js
+++ b/test/Player.js
@@ -144,7 +144,8 @@ test('progress()', t => {
     load,
     getCurrentTime: sinon.fake.returns(10),
     getSecondsLoaded: sinon.fake.returns(20),
-    getDuration: sinon.fake.returns(40)
+    getDuration: sinon.fake.returns(40),
+    getIsMuted: sinon.fake.returns(false)
   })
   instance.isReady = true
   instance.progress()
@@ -153,7 +154,8 @@ test('progress()', t => {
     loaded: 0.5,
     loadedSeconds: 20,
     played: 0.25,
-    playedSeconds: 10
+    playedSeconds: 10,
+    isMuted: false
   }))
 })
 


### PR DESCRIPTION
This will provide the `muted` status of the video player inside `onProgress` props.
The actual case is when user clicking the mute button on the control player, currently we cannot track the `muted` status on it.

<img width="229" alt="Screen Shot 2020-06-06 at 01 54 05" src="https://user-images.githubusercontent.com/29223530/83912781-9d0d8d00-a798-11ea-9dc7-e048feba434b.png">