### PR TITLE
dashjs deprecated method fix for different versions.

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -144,7 +144,11 @@ export default class FilePlayer extends Component {
         this.dash = dashjs.MediaPlayer().create()
         this.dash.initialize(this.player, url, this.props.playing)
         this.dash.on('error', this.props.onError)
-        this.dash.getDebug().setLogToBrowserConsole(false)
+        if (parseInt(dashVersion) < 3) {
+          this.dash.getDebug().setLogToBrowserConsole(false)
+        } else {
+          this.dash.updateSettings({ debug: { logLevel: dashjs.Debug.LOG_LEVEL_NONE } })
+        }
       })
     }
 

--- a/test/players/FilePlayer.js
+++ b/test/players/FilePlayer.js
@@ -106,7 +106,8 @@ test('load - dash', async t => {
         initialize: () => null,
         getDebug: () => ({
           setLogToBrowserConsole: () => t.pass()
-        })
+        }),
+        updateSettings: () => t.pass()
       })
     })
   }


### PR DESCRIPTION
issue [#932](https://github.com/CookPete/react-player/issues/932) fixed.