### PR TITLE
Hide wistia controls with controls prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ package-lock.json
 /lazy
 /demo
 /coverage
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Prop | Description | Default
 `url` | The url of a video or song to play<br/>&nbsp; ◦ &nbsp;Can be an [array](#multiple-sources-and-tracks) or [`MediaStream`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) object
 `playing` | Set to `true` or `false` to pause or play the media | `false`
 `loop` | Set to `true` or `false` to loop the media | `false`
-`controls` | Set to `true` or `false` to display native player controls<br />&nbsp; ◦ &nbsp;Controls cannot be hidden for Wistia videos | `false`
+`controls` | Set to `true` or `false` to display native player controls | `false`
 `light` | Set to `true` to show just the video thumbnail, which loads the full player on click<br />&nbsp; ◦ &nbsp;Pass in an image URL to override the preview image | `false`
 `volume` | Set the volume of the player, between `0` and `1`<br/>&nbsp; ◦ &nbsp;`null` uses default volume on all players [`#357`](https://github.com/CookPete/react-player/issues/357) | `null`
 `muted` | Mutes the player<br/>&nbsp; ◦ &nbsp;Only works if `volume` is set | `false`

--- a/src/players/Wistia.js
+++ b/src/players/Wistia.js
@@ -29,6 +29,14 @@ export default class Wistia extends Component {
           silentAutoPlay: 'allow',
           muted: muted,
           controlsVisibleOnLoad: controls,
+          fullscreenButton: controls,
+          playbar: controls,
+          playbackRateControl: controls,
+          qualityControl: controls,
+          volumeControl: controls,
+          playButton: controls,
+          settingsControl: controls,
+          smallPlayButton: controls,
           ...config.options
         },
         onReady: player => {

--- a/src/players/Wistia.js
+++ b/src/players/Wistia.js
@@ -34,7 +34,6 @@ export default class Wistia extends Component {
           playbackRateControl: controls,
           qualityControl: controls,
           volumeControl: controls,
-          playButton: controls,
           settingsControl: controls,
           smallPlayButton: controls,
           ...config.options

--- a/src/props.js
+++ b/src/props.js
@@ -55,7 +55,8 @@ export const propTypes = {
       dashVersion: string
     }),
     wistia: shape({
-      options: object
+      options: object,
+      playerId: string
     }),
     mixcloud: shape({
       options: object
@@ -154,7 +155,8 @@ export const defaultProps = {
       dashVersion: '2.9.2'
     },
     wistia: {
-      options: {}
+      options: {},
+      playerId: null
     },
     mixcloud: {
       options: {


### PR DESCRIPTION
Now, user can hide wistia player controls by providing control props false.