### PR TITLE
Add Cloudflare Stream content player

### DIFF
--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -348,6 +348,12 @@ class App extends Component {
                 </td>
               </tr>
               <tr>
+                <th>Cloudflare Stream</th>
+                <td>
+                  {this.renderLoadButton('https://watch.cloudflarestream.com/5d5bc37ffcf54c9b82e996823bffbb81', 'Test A')}
+                </td>
+              </tr>
+              <tr>
                 <th>Files</th>
                 <td>
                   {this.renderLoadButton('http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4', 'mp4')}

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -11,6 +11,7 @@ export const MATCH_URL_TWITCH_CHANNEL = /(?:www\.|go\.)?twitch\.tv\/([a-zA-Z0-9_
 export const MATCH_URL_DAILYMOTION = /^(?:(?:https?):)?(?:\/\/)?(?:www\.)?(?:(?:dailymotion\.com(?:\/embed)?\/video)|dai\.ly)\/([a-zA-Z0-9]+)(?:_[\w_-]+)?$/
 export const MATCH_URL_MIXCLOUD = /mixcloud\.com\/([^/]+\/[^/]+)/
 export const MATCH_URL_VIDYARD = /vidyard.com\/(?:watch\/)?([a-zA-Z0-9-]+)/
+export const MATCH_URL_CLOUDFLARESTREAM = /watch.cloudflarestream\.com\/.+/
 export const AUDIO_EXTENSIONS = /\.(m4a|mp4a|mpga|mp2|mp2a|mp3|m2a|m3a|wav|weba|aac|oga|spx)($|\?)/i
 export const VIDEO_EXTENSIONS = /\.(mp4|og[gv]|webm|mov|m4v)($|\?)/i
 export const HLS_EXTENSIONS = /\.(m3u8)($|\?)/i
@@ -55,5 +56,6 @@ export const canPlay = {
   dailymotion: url => MATCH_URL_DAILYMOTION.test(url),
   mixcloud: url => MATCH_URL_MIXCLOUD.test(url),
   vidyard: url => MATCH_URL_VIDYARD.test(url),
+  cloudflareStream: url => MATCH_URL_CLOUDFLARESTREAM.test(url),
   file: canPlayFile
 }

--- a/src/players/CloudflareStream.js
+++ b/src/players/CloudflareStream.js
@@ -1,0 +1,135 @@
+import React, { Component } from 'react'
+
+import { callPlayer } from '../utils'
+import { canPlay, MATCH_URL_CLOUDFLARESTREAM } from '../patterns'
+
+export default class CloudflareStream extends Component {
+  static displayName = 'CloudFlare'
+  static canPlay = canPlay.cloudflare
+  callPlayer = callPlayer
+
+  componentDidMount () {
+    this.props.onMount && this.props.onMount(this)
+  }
+
+  componentDidUpdate () {
+    if (this.props.playing) {
+      this.play()
+    } else {
+      this.pause()
+    }
+  }
+
+  componentWillUnmount () {
+    document.body.removeChild(this.script)
+  }
+
+  load (url) {
+    console.log('Cloudflarestream player loaded')
+
+    if (MATCH_URL_CLOUDFLARESTREAM.test(url)) {
+      this.props.onReady()
+
+      const src = url.substring(url.lastIndexOf('/') + 1)
+      this.script = document.createElement('script')
+      this.script.src = `https://embed.cloudflarestream.com/embed/r4xu.fla9.latest.js?video=${src}`
+      this.script['data-cfasync'] = 'false'
+      this.script.defer = true
+      this.script.type = 'text/javascript'
+      document.body.appendChild(this.script)
+
+      this.player = document.getElementById('cloudflareStreamPlayer')
+    } else {
+      this.props.onError('Cloudflare player needs to take a Cloudflare Stream URL')
+    }
+  }
+
+  refreshDuration () {
+    this.player.getDuration().then(duration => {
+      this.duration = duration
+    })
+  }
+
+  play () {
+    this.callPlayer('play')
+  }
+
+  pause () {
+    this.callPlayer('pause')
+  }
+
+  stop () {
+    this.callPlayer('unload')
+  }
+
+  seekTo (seconds) {
+    if (this.player) {
+      this.player.currentTime = seconds
+    }
+  }
+
+  setVolume (fraction) {
+    if (this.player) {
+      this.player.volume = fraction
+    }
+  }
+
+  setLoop (loop) {
+    if (this.player) {
+      this.player.loop = loop
+    }
+  }
+
+  setPlaybackRate (rate) {
+    this.callPlayer('setPlaybackRate', rate)
+  }
+
+  mute = () => {
+    this.player.muted = true
+  }
+
+  unmute = () => {
+    if (this.props.volume !== null) {
+      this.setVolume(this.props.volume)
+      this.player.muted = false
+    }
+  }
+
+  getDuration () {
+    return this.player && this.player.duration
+  }
+
+  getCurrentTime () {
+    return this.player && this.player.currentTime
+  }
+
+  getSecondsLoaded () {
+    console.log('getSecondsLoaded returns current time because Cloudflare does not have a loaded property')
+    return this.player && this.player.currentTime
+  }
+
+  ref = container => {
+    this.container = container
+  }
+
+  render () {
+    const { display, url, muted } = this.props
+
+    const src = url.substring(url.lastIndexOf('/') + 1)
+    const style = {
+      width: '100%',
+      height: '100%',
+      overflow: 'hidden',
+      display
+    }
+    return (
+      <div
+        key='cloudflareStream'
+        ref={this.ref}
+        style={style}
+      >
+        <stream autoplay id='cloudflareStreamPlayer' preload='auto' src={src} controls={this.props.controls} muted={muted} />
+      </div>
+    )
+  }
+}

--- a/src/players/index.js
+++ b/src/players/index.js
@@ -64,6 +64,12 @@ export default [
     lazyPlayer: lazy(() => import(/* webpackChunkName: 'reactPlayerVidyard' */'./Vidyard'))
   },
   {
+    key: 'cloudflareStream',
+    name: 'Cloudflare Stream',
+    canPlay: canPlay.cloudflareStream,
+    lazyPlayer: lazy(() => import(/* webpackChunkName: 'reactPlayerCloudflareStream' */'./CloudflareStream'))
+  },
+  {
     key: 'file',
     name: 'FilePlayer',
     canPlay: canPlay.file,


### PR DESCRIPTION
Cloudflare Stream is an easy-to-use, affordable, on-demand video streaming platform.
It handles video storage, encoding, and a customizable player with Cloudflare’s fast, secure, and reliable global network

This adds support for their player using their Javascript API.