### PR TITLE
Make force disabling PIP dependent on prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Prop | Description | Default
 `progressInterval` | The time between `onProgress` callbacks, in milliseconds | `1000`
 `playsinline` | Applies the `playsinline` attribute where supported | `false`
 `pip` | Set to `true` or `false` to enable or disable [picture-in-picture mode](https://developers.google.com/web/updates/2018/10/watch-video-using-picture-in-picture)<br/>&nbsp; ◦ &nbsp;Only available when playing file URLs in [certain browsers](https://caniuse.com/#feat=picture-in-picture) | `false`
-`disablePIPOnUnmount` | Set to `true` or `false` to disable pip once video is unmounted or leave it running <br/>&nbsp; ◦ &nbsp;Only available when playing file URLs in [certain browsers](https://caniuse.com/#feat=picture-in-picture) | `false`
+`stopOnUnmount` | If you are using `pip` you may want to use `stopOnUnmount={false}` to continue playing in picture-in-picture mode even after ReactPlayer unmounts | `true`
 `wrapper` | Element or component to use as the container element | `div`
 `playIcon` | Element or component to use as the play icon in light mode
 `config` | Override options for the various players, see [config prop](#config-prop)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Prop | Description | Default
 `progressInterval` | The time between `onProgress` callbacks, in milliseconds | `1000`
 `playsinline` | Applies the `playsinline` attribute where supported | `false`
 `pip` | Set to `true` or `false` to enable or disable [picture-in-picture mode](https://developers.google.com/web/updates/2018/10/watch-video-using-picture-in-picture)<br/>&nbsp; ◦ &nbsp;Only available when playing file URLs in [certain browsers](https://caniuse.com/#feat=picture-in-picture) | `false`
+`disablePIPOnUnmount` | Set to `true` or `false` to disable pip once video is unmounted or leave it running <br/>&nbsp; ◦ &nbsp;Only available when playing file URLs in [certain browsers](https://caniuse.com/#feat=picture-in-picture) | `false`
 `wrapper` | Element or component to use as the container element | `div`
 `playIcon` | Element or component to use as the play icon in light mode
 `config` | Override options for the various players, see [config prop](#config-prop)

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,6 +88,7 @@ export interface ReactPlayerProps {
   progressInterval?: number;
   playsinline?: boolean;
   pip?: boolean;
+  stopOnUnmount?: boolean;
   light?: boolean | string;
   wrapper?: any;
   config?: Config;

--- a/src/Player.js
+++ b/src/Player.js
@@ -26,7 +26,7 @@ export default class Player extends Component {
   componentWillUnmount () {
     clearTimeout(this.progressTimeout)
     clearTimeout(this.durationCheckTimeout)
-    if (this.isReady) {
+    if (this.isReady && this.props.disablePIPOnUnmount) {
       this.player.stop()
 
       if (this.player.disablePIP) {

--- a/src/Player.js
+++ b/src/Player.js
@@ -26,7 +26,7 @@ export default class Player extends Component {
   componentWillUnmount () {
     clearTimeout(this.progressTimeout)
     clearTimeout(this.durationCheckTimeout)
-    if (this.isReady && this.props.disablePIPOnUnmount) {
+    if (this.isReady && this.props.stopOnUnmount) {
       this.player.stop()
 
       if (this.player.disablePIP) {

--- a/src/props.js
+++ b/src/props.js
@@ -16,7 +16,7 @@ export const propTypes = {
   progressInterval: number,
   playsinline: bool,
   pip: bool,
-  disablePIPOnUnmount: bool,
+  stopOnUnmount: bool,
   light: oneOfType([bool, string]),
   playIcon: node,
   wrapper: oneOfType([
@@ -102,7 +102,7 @@ export const defaultProps = {
   progressInterval: 1000,
   playsinline: false,
   pip: false,
-  disablePIPOnUnmount: false,
+  stopOnUnmount: true,
   light: false,
   wrapper: 'div',
   config: {

--- a/src/props.js
+++ b/src/props.js
@@ -16,6 +16,7 @@ export const propTypes = {
   progressInterval: number,
   playsinline: bool,
   pip: bool,
+  disablePIPOnUnmount: bool,
   light: oneOfType([bool, string]),
   playIcon: node,
   wrapper: oneOfType([
@@ -101,6 +102,7 @@ export const defaultProps = {
   progressInterval: 1000,
   playsinline: false,
   pip: false,
+  disablePIPOnUnmount: false,
   light: false,
   wrapper: 'div',
   config: {


### PR DESCRIPTION
This is a great library and thank you for creating and maintaining it @CookPete . I was stoked to see that the library has support PIP but it feels a bit backwards to disable/remove pip when video is unmounted when most of the time, PIP is intended to be fired when the video is not explicitly visible and other content is given priority. However, as the library owner, I fully respect your decision to implement the UX you think is right for the library. So, this PR does not override the behavior you've implemented and adds a new prop to opt-in for that as a feature.