### PR TITLE
vimeo: listen for bufferring events and handle with matching callbacks

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -55,6 +55,8 @@ export default class Vimeo extends Component {
       this.player.on('progress', ({ seconds }) => {
         this.secondsLoaded = seconds
       })
+      this.player.on('bufferstart', this.props.onBuffer)
+      this.player.on('bufferend', this.props.onBufferEnd)
     }, this.props.onError)
   }
 


### PR DESCRIPTION
Hey there, thanks for the nice player, it's been great for us.

Just wanted to a add a small feature for our use case: being able to use the `onBuffer` and `onBufferEnd` callbacks with the vimeo player.

A very basic change, following the Vimeo spec:
https://developer.vimeo.com/player/sdk/reference#bufferstart
https://developer.vimeo.com/player/sdk/reference#bufferend