### PR TITLE
Add descriptive text to Controls section

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Prop | Description | Default
 `url` | The url of a video or song to play<br/>&nbsp; ◦ &nbsp;Can be an [array](#multiple-sources-and-tracks) or [`MediaStream`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) object
 `playing` | Set to `true` or `false` to pause or play the media | `false`
 `loop` | Set to `true` or `false` to loop the media | `false`
-`controls` | Set to `true` or `false` to display native player controls | `false`
+`controls` | Set to `true` or `false` to display native player controls. (*Note for Vimeo: This is only available to Pro, Plus, or Business Members*) | `false`
 `light` | Set to `true` to show just the video thumbnail, which loads the full player on click<br />&nbsp; ◦ &nbsp;Pass in an image URL to override the preview image | `false`
 `volume` | Set the volume of the player, between `0` and `1`<br/>&nbsp; ◦ &nbsp;`null` uses default volume on all players [`#357`](https://github.com/CookPete/react-player/issues/357) | `null`
 `muted` | Mutes the player<br/>&nbsp; ◦ &nbsp;Only works if `volume` is set | `false`


### PR DESCRIPTION
After running into the same issue as this: https://github.com/CookPete/react-player/issues/970,  I'm adding this description to the README for clarity