### PR TITLE
Fixes youtube player playsinline variable type

### DIFF
--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -56,7 +56,7 @@ export default class YouTube extends Component {
           start: parseStartTime(url),
           end: parseEndTime(url),
           origin: window.location.origin,
-          playsinline: playsinline,
+          playsinline: playsinline ? 1 : 0,
           ...this.parsePlaylist(url),
           ...playerVars
         },


### PR DESCRIPTION
I found this bug when embedding a Youtube player on Safari mobile. Passing true would create `playsinline=true`, which didn't enable the inline playback. I could fix it by passing `1` as value, but then I got this warning: `Warning: Failed prop type: Invalid prop 'playsinline' of type 'number' supplied to 'Player', expected 'boolean'.`

`playsinline` should be a number as per the Youtube player documentation: https://developers.google.com/youtube/player_parameters#playsinline

_Valid values are:
0: This value causes fullscreen playback. This is currently the default value, though the default is subject to change.
1: This value causes inline playback for UIWebViews created with the allowsInlineMediaPlayback property set to TRUE._