### PR TITLE
Add explicit comment to set muted to true for autoplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For platforms without direct use of `npm` modules, a minified version of `ReactP
 
 #### Autoplay
 
-As of Chrome 66, [videos must be `muted` in order to play automatically](https://www.theverge.com/2018/3/22/17150870/google-chrome-autoplay-videos-sound-mute-update). Some players, like Facebook, cannot be unmuted until the user interacts with the video, so you may want to enable `controls` to allow users to unmute videos themselves.
+As of Chrome 66, [videos must be `muted` in order to play automatically](https://www.theverge.com/2018/3/22/17150870/google-chrome-autoplay-videos-sound-mute-update). Some players, like Facebook, cannot be unmuted until the user interacts with the video, so you may want to enable `controls` to allow users to unmute videos themselves. Please set `muted={true}`.
 
 ### Props
 


### PR DESCRIPTION
Previously, I skipped over the Autoplay portion thinking that with the UI mic icon disabled and faded, muted was true, already. This has led to hours trying to figure out why playing doesn't start when player is loaded and ready.

Hopefully, this explicit change will help others save hours of hackery.

@CookPete 