### PR TITLE
Updates the default version of dash.js, hls.js

### DIFF
--- a/src/props.js
+++ b/src/props.js
@@ -156,8 +156,8 @@ export const defaultProps = {
       forceDASH: false,
       forceFLV: false,
       hlsOptions: {},
-      hlsVersion: '0.13.1',
-      dashVersion: '2.9.2',
+      hlsVersion: '0.14.16',
+      dashVersion: '3.1.3',
       flvVersion: '1.5.0'
     },
     wistia: {


### PR DESCRIPTION
The default versions of hls.js and dash.js used are several releases out of date, and so by default are missing several good features. While it is possible to specify different versions for these in the configuration, I think it is valuable to keep the default versions being used up to date.