### PR TITLE
fix: add playIcon prop to TS declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,7 @@ export interface ReactPlayerProps {
   style?: Object;
   progressInterval?: number;
   playsinline?: boolean;
+  playIcon?: React.ReactElement;
   pip?: boolean;
   stopOnUnmount?: boolean;
   light?: boolean | string;


### PR DESCRIPTION
`playIcon` is currently missing from the .d.ts file.