### PR TITLE
Fix/extract youtube config

### DIFF
--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -29,7 +29,7 @@ export default class YouTube extends Component {
 
   load (url, isReady) {
     const { playing, muted, playsinline, controls, loop, config, onError } = this.props
-    const { playerVars, embedOptions } = config
+    const { youtube: { playerVars, embedOptions } } = config
     const id = this.getID(url)
     if (isReady) {
       if (MATCH_PLAYLIST.test(url) || MATCH_USER_UPLOADS.test(url) || url instanceof Array) {

--- a/test/players/YouTube.js
+++ b/test/players/YouTube.js
@@ -25,8 +25,10 @@ configure({ adapter: new Adapter() })
 
 const TEST_URL = 'https://www.youtube.com/watch?v=oUFJJNQGwhk'
 const TEST_CONFIG = {
-  playerVars: {},
-  embedOptions: {}
+  youtube: {
+    playerVars: {},
+    embedOptions: {}
+  }
 }
 
 testPlayerMethods(YouTube, {


### PR DESCRIPTION
## Description

According to docs youtube config parameters are extracted from youtube key:

```
There is a single config prop to override settings for each type of player:

<ReactPlayer
  url={url}
  config={{
    youtube: {
      playerVars: { showinfo: 1 }
    },
    facebook: {
    ...
```

However, in reality these where extracted from top level.  Therefore user settings were practically ignored.

Note that is is potentially breaking change if some library users have used the youtube configs from top level (against what is instructed documentation).

## Solution

Extract youtube configs under youtube key as documented.

## Notes

I come across this when trying to find solution for an old issue https://github.com/cookpete/react-player/issues/508
To my understanding this can be solved by passing `enablejsapi: 1` as playerVar (with explicit origin too if needed).

However, I was unable to get this working until I figured out that youtube playerVars were extracted differently than documentation explains.
