### PR TITLE
fix: remove srcObject attribute if next uri is not a MediaStream

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -33,6 +33,13 @@ export default class FilePlayer extends Component {
       this.removeListeners(this.prevPlayer, prevProps.url)
       this.addListeners(this.player)
     }
+
+    if (
+      this.props.url !== prevProps.url &&
+      !isMediaStream(this.props.url)
+    ) {
+      this.player.removeAttribute('srcObject')
+    }
   }
 
   componentWillUnmount () {

--- a/test/players/FilePlayer.js
+++ b/test/players/FilePlayer.js
@@ -393,3 +393,13 @@ test('auto width/height', t => {
     </video>
   ))
 })
+
+test('clear srcObject on url change', t => {
+  const url = new MockMediaStream()
+  const wrapper = shallow(<FilePlayer url={url} config={config} />)
+  const instance = wrapper.instance()
+  instance.player.removeAttribute = sinon.fake()
+  instance.load(url)
+  wrapper.setProps({ url: 'file.mpv' })
+  t.true(instance.player.removeAttribute.calledOnceWith('srcObject'))
+})


### PR DESCRIPTION
Currenlty if you pass MediaStream to FilePlayer, and then change it to something that is not MediaStream, player keeps old srcObject and brokes. This PR fix this behavior and add regression test.