### PR TITLE
Add missing FLV properties to TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,9 +57,11 @@ export interface FileConfig {
   forceAudio?: boolean;
   forceHLS?: boolean;
   forceDASH?: boolean;
+  forceFLV?: boolean;
   hlsOptions?: Object;
   hlsVersion?: string;
   dashVersion?: string;
+  flvVersion?: string;
 }
 
 export interface TwitchConfig {


### PR DESCRIPTION
There are a couple of FLV properties﻿ missing from `index.d.ts` -- this adds them.
