### PR TITLE
Remove tabIndex from preview component

### DIFF
--- a/src/Preview.js
+++ b/src/Preview.js
@@ -95,7 +95,6 @@ export default class Preview extends Component {
         style={styles.preview}
         className='react-player__preview'
         onClick={onClick}
-        tabIndex={0}
         onKeyPress={this.handleKeyPress}
       >
         {playIcon || defaultPlayIcon}


### PR DESCRIPTION
Hi!

Currently developing a project that uses react-player and we are using a custom focus system. Having this `tabIndex` on the preview is sadly breaking it, and there is no easy way to remove it.

I think the `tabIndex` should be handled by the user implementing the player (Aka : wrap it around a div with tabindex)