### PR TITLE
Handle setPlaybackRate error

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -264,7 +264,11 @@ export default class FilePlayer extends Component {
   }
 
   setPlaybackRate (rate) {
-    this.player.playbackRate = rate
+    try {
+      this.player.playbackRate = rate
+    } catch (error) {
+      this.props.onError(error)
+    }
   }
 
   getDuration () {


### PR DESCRIPTION
setPlaybackRate can throw error:

```
DOMException: Failed to set the 'playbackRate' property on 'HTMLMediaElement': The provided playback rate (20) is not in the supported playback range.
```

For now this exception is unhandled.

It needs to be inside try / catch:

https://googlechrome.github.io/samples/media/playback-rate-exception