### PR TITLE
Adjust listener for kaltura

### DIFF
--- a/src/players/Kaltura.js
+++ b/src/players/Kaltura.js
@@ -24,8 +24,8 @@ export default class Kaltura extends Component {
       if (!this.iframe) return
       this.player = new playerjs.Player(this.iframe)
       this.player.on('ready', () => {
-        // an arbitrary timeout is is required,
-        // otherwise the eventListeners won't work
+        // An arbitrary timeout is required otherwise
+        // the event listeners won’t work
         setTimeout(() => {
           this.player.isReady = true
           this.player.setLoop(this.props.loop)

--- a/src/players/Kaltura.js
+++ b/src/players/Kaltura.js
@@ -111,7 +111,7 @@ export default class Kaltura extends Component {
         scrolling='no'
         style={style}
         allowFullScreen
-        allow='encrypted-media'
+        allow='encrypted-media;autoplay'
         referrerPolicy='no-referrer-when-downgrade'
       />
     )

--- a/src/players/Kaltura.js
+++ b/src/players/Kaltura.js
@@ -39,7 +39,7 @@ export default class Kaltura extends Component {
     // wait what?
   }
 
-  addListeners(player, props) {
+  addListeners (player, props) {
     player.on('play', props.onPlay)
     player.on('pause', props.onPause)
     player.on('ended', props.onEnded)
@@ -48,7 +48,6 @@ export default class Kaltura extends Component {
       this.duration = duration
       this.currentTime = seconds
     })
-
   }
 
   play () {

--- a/src/players/Kaltura.js
+++ b/src/players/Kaltura.js
@@ -16,6 +16,10 @@ export default class Kaltura extends Component {
 
   componentDidMount () {
     this.props.onMount && this.props.onMount(this)
+    this.load()
+  }
+
+  load (url) {
     getSDK(SDK_URL, SDK_GLOBAL).then(playerjs => {
       if (!this.iframe) return
       this.player = new playerjs.Player(this.iframe)
@@ -33,10 +37,6 @@ export default class Kaltura extends Component {
         }, 500)
       })
     }, this.props.onError)
-  }
-
-  load (url) {
-    // wait what?
   }
 
   addListeners (player, props) {

--- a/src/players/Kaltura.js
+++ b/src/players/Kaltura.js
@@ -16,7 +16,6 @@ export default class Kaltura extends Component {
 
   componentDidMount () {
     this.props.onMount && this.props.onMount(this)
-    this.load()
   }
 
   load (url) {

--- a/src/players/Kaltura.js
+++ b/src/players/Kaltura.js
@@ -16,37 +16,39 @@ export default class Kaltura extends Component {
 
   componentDidMount () {
     this.props.onMount && this.props.onMount(this)
-  }
-
-  load (url) {
     getSDK(SDK_URL, SDK_GLOBAL).then(playerjs => {
       if (!this.iframe) return
       this.player = new playerjs.Player(this.iframe)
       this.player.on('ready', () => {
-        this.player.isReady = true
-        this.player.on('play', this.props.onPlay)
-        this.player.on('pause', this.props.onPause)
-        this.player.on('seeked', this.props.onSeek)
-        this.player.on('ended', this.props.onEnded)
-        this.player.on('error', this.props.onError)
-        this.player.on('timeupdate', ({ duration, seconds }) => {
-          this.duration = duration
-          this.currentTime = seconds
-        })
-        this.player.on('buffered', ({ percent }) => {
-          if (this.duration) {
-            this.secondsLoaded = this.duration * percent
-          }
-        })
-        this.player.setLoop(this.props.loop)
-        if (this.props.muted) {
-          this.player.mute()
-        }
+        // an arbitrary timeout is is required,
+        // otherwise the eventListeners won't work
         setTimeout(() => {
+          this.player.isReady = true
+          this.player.setLoop(this.props.loop)
+          if (this.props.muted) {
+            this.player.mute()
+          }
+          this.addListeners(this.player, this.props)
           this.props.onReady()
-        })
+        }, 500)
       })
     }, this.props.onError)
+  }
+
+  load (url) {
+    // wait what?
+  }
+
+  addListeners(player, props) {
+    player.on('play', props.onPlay)
+    player.on('pause', props.onPause)
+    player.on('ended', props.onEnded)
+    player.on('error', props.onError)
+    player.on('timeupdate', ({ duration, seconds }) => {
+      this.duration = duration
+      this.currentTime = seconds
+    })
+
   }
 
   play () {


### PR DESCRIPTION
Fixes #1202 and related to #1082.

Strangely it is necessary to wait a bit for the player to be ready, even after the `onReady` event fired. Otherwise the added event listeners would just be ignored as there is no warning or error message.

After my adjustments I can now consistently reproduce seeking (in-player and via react-player), play/pause (in-player and via react-player).

Nevertheless there is still no support for:
- playbackRate
- volume update (setting inside the player won't propagate to react-player)
- controls option

Manual investigation (`console.log(this.player.events)`) of the API shows, that the internal player only supports these events:
- "ready"
- "play"
- "pause"
- "ended"
- "timeupdate"
- "progress"
- "error"
