### PR TITLE
add title attribute to vimeo iframe

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -36,6 +36,7 @@ export default class Vimeo extends Component {
         const iframe = this.container.querySelector('iframe')
         iframe.style.width = '100%'
         iframe.style.height = '100%'
+        iframe.title = this.props.title
       }).catch(this.props.onError)
       this.player.on('loaded', () => {
         this.props.onReady()

--- a/src/props.js
+++ b/src/props.js
@@ -89,7 +89,8 @@ export const propTypes = {
   onProgress: func,
   onClickPreview: func,
   onEnablePIP: func,
-  onDisablePIP: func
+  onDisablePIP: func,
+  title: string
 }
 
 const noop = () => {}
@@ -199,5 +200,6 @@ export const defaultProps = {
   onProgress: noop,
   onClickPreview: noop,
   onEnablePIP: noop,
-  onDisablePIP: noop
+  onDisablePIP: noop,
+  title: ""
 }


### PR DESCRIPTION
This adds `title` as a supported prop for `<ReactPlayer />`.  When `<ReactPlayer />` is a `<Vimeo />` component that title will appear as a title attribute on the `iframe` within the container.

Having a title attribute on an `iframe` is critical for screen reader users to tell them what is contained within that element.

more info on this topic from W3 can be found [here](https://www.w3.org/TR/WCAG20-TECHS/H64.html#:~:text=The%20objective%20of%20this%20technique,enter%20and%20explore%20in%20detail.&text=The%20iframe%20element%20remains%20part%20of%20the%20HTML5%20specification)