### PR TITLE
Add media attribute to source tag in file player

### DIFF
--- a/test/players/FilePlayer.js
+++ b/test/players/FilePlayer.js
@@ -343,6 +343,7 @@ test('render - string array', t => {
 
 test('render - object array', t => {
   const url = [
+    { src: 'file.mp4', type: 'video/mp4', media: '(max-width:800px)' },
     { src: 'file.mp4', type: 'video/mp4' },
     { src: 'file.ogg', type: 'video/ogg' }
   ]
@@ -350,7 +351,8 @@ test('render - object array', t => {
   t.true(wrapper.containsMatchingElement(
     <video src={undefined}>
       {[
-        <source key={0} src='file.mp4' type='video/mp4' />,
+        <source key={0} src='file.mp4' type='video/mp4' media='(max-width:800px)' />,
+        <source key={1} src='file.mp4' type='video/mp4' />,
         <source key={1} src='file.ogg' type='video/ogg' />
       ]}
       {[]}

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -2,8 +2,9 @@ import { Component, ReactElement, CSSProperties } from 'react'
 import ReactPlayer from './lib'
 
 interface SourceProps {
+  media?: string
   src: string
-  type: string
+  type?: string
 }
 
 export interface BaseReactPlayerProps {


### PR DESCRIPTION
When using react-player's file player in a typescript project, I noticed that the media attribute is missing in the type definitions. (When working around the types, the media attribute shows up in the `<video>` element due to the spreading operation in the [code](https://github.com/cookpete/react-player/blob/master/src/players/FilePlayer.js#L317).)

Although, unfortunately, the media attribute [seems to be ignored by some browsers](https://stackoverflow.com/questions/25907930/chrome-not-respecting-video-source-inline-media-queries), it's still [part of HTML 5](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source). I am therefore suggesting to add it to the type definitions and fix the functionality by the test I extended.