### PR TITLE
Youtube: On ready event

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -160,12 +160,12 @@ export default class Player extends Component {
     this.player.seekTo(amount)
   }
 
-  handleReady = () => {
+  handleReady = (event) => {
     if (!this.mounted) return
     this.isReady = true
     this.isLoading = false
     const { onReady, playing, volume, muted } = this.props
-    onReady()
+    onReady(event)
     if (!muted && volume !== null) {
       this.player.setVolume(volume)
     }

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -103,8 +103,8 @@ export const createReactPlayer = (players, fallback) => {
       this.player.seekTo(fraction, type)
     }
 
-    handleReady = () => {
-      this.props.onReady(this)
+    handleReady = (event) => {
+      this.props.onReady(this, event)
     }
 
     getActivePlayer = memoize(url => {

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -61,11 +61,11 @@ export default class YouTube extends Component {
           ...playerVars
         },
         events: {
-          onReady: () => {
+          onReady: (event) => {
             if (loop) {
               this.player.setLoop(true) // Enable playlist looping
             }
-            this.props.onReady()
+            this.props.onReady(event)
           },
           onStateChange: this.onStateChange,
           onError: event => onError(event.data)


### PR DESCRIPTION
Currently, there is no way to get access to the YT target Element that includes video metadata such as **target.videoinfo** 
videoinfo also includes the video `title`, `author`, and `availablePlaybackRates`.

This PR is passing the event through onReady as an argument.