### PR TITLE
Make facebook config type properties optional

### DIFF
--- a/types/facebook.d.ts
+++ b/types/facebook.d.ts
@@ -1,9 +1,9 @@
 import BaseReactPlayer, { BaseReactPlayerProps } from './base'
 
 export interface FacebookConfig {
-  appId: string
-  version: string
-  playerId: string
+  appId?: string
+  version?: string
+  playerId?: string
 }
 
 export interface FacebookPlayerProps extends BaseReactPlayerProps {


### PR DESCRIPTION
Fix for the below issue when using react-player facebook config in typescript

#### Current Behavior
- Using react-player with typescript 
- when trying to pass facebook config the type definitions require all config fields.
- Typescript flags it as an error if you just try to pass one prop e.g. `appId`.

#### Expected Behavior

Should be able to configure as per the sample in the docs:
```html
<ReactPlayer
  url={url}
  config={{
    youtube: {
      playerVars: { showinfo: 1 }
    },
    facebook: {
      appId: '12345'
    }
  }}
/>
```