### PR TITLE
Add oEmbedUrl as changeable prop

### DIFF
--- a/src/Preview.js
+++ b/src/Preview.js
@@ -26,7 +26,7 @@ export default class Preview extends Component {
     this.mounted = false
   }
 
-  fetchImage ({ url, light, oEmbedUrl = 'https://noembed.com/embed' }) {
+  fetchImage ({ url, light, oEmbedUrl }) {
     if (typeof light === 'string') {
       this.setState({ image: light })
       return
@@ -36,7 +36,7 @@ export default class Preview extends Component {
       return
     }
     this.setState({ image: null })
-    return window.fetch(`${oEmbedUrl}?url=${url}`)
+    return window.fetch(oEmbedUrl.replace('{url}', url))
       .then(response => response.json())
       .then(data => {
         if (data.thumbnail_url && this.mounted) {

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -142,8 +142,8 @@ export const createReactPlayer = (players, fallback) => {
           light={light}
           playIcon={playIcon}
           previewTabIndex={previewTabIndex}
-          onClick={this.handleClickPreview}
           oEmbedUrl={oEmbedUrl}
+          onClick={this.handleClickPreview}
         />
       )
     }

--- a/src/props.js
+++ b/src/props.js
@@ -21,6 +21,7 @@ export const propTypes = {
   playIcon: node,
   previewTabIndex: number,
   fallback: node,
+  oEmbedUrl: string,
   wrapper: oneOfType([
     string,
     func,
@@ -112,6 +113,7 @@ export const defaultProps = {
   fallback: null,
   wrapper: 'div',
   previewTabIndex: 0,
+  oEmbedUrl: 'https://noembed.com/embed?url={url}',
   config: {
     soundcloud: {
       options: {


### PR DESCRIPTION
This change makes it possible to use another service for retrieving the preview image.

I tested the code by adding this property to `ReactPlayer` in App.js:

```js
oEmbedUrl='https://api.playerx.io/oembed'
```

Noembed doesn't seem to be maintained anymore and there is no purge cache support and the default cache is set to expire after 100 days.

I started a new oEmbed service with purge support over at https://github.com/playerxo/oembed
It's hosted on Cloudflare workers which offers a generous free tier and it's written in Javascript.
Feel free to use it or host your own with the pubic code.