### PR TITLE
Add attributes in FacebookConfig type

### DIFF
--- a/types/facebook.d.ts
+++ b/types/facebook.d.ts
@@ -4,6 +4,7 @@ export interface FacebookConfig {
   appId?: string
   version?: string
   playerId?: string
+  attributes?: object
 }
 
 export interface FacebookPlayerProps extends BaseReactPlayerProps {


### PR DESCRIPTION
Fix for the below issue when using react-player facebook config in typescript

**Current Behavior**

- Using react-player with typescript
- Typescript flags it as an error if try to pass attributes to FacebookConfig

**Expected Behavior**

Should be able to configure as below

```
<ReactPlayer
  url={url}
  config={{
    facebook: {
      attributes: {
        height: "480px"
    }
  }}
/>
```