### PR TITLE
(fix): clear video src to prevent old video from continue loading

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -43,6 +43,7 @@ export default class FilePlayer extends Component {
   }
 
   componentWillUnmount () {
+    this.player.src = ''
     this.removeListeners(this.player)
     if (this.hls) {
       this.hls.destroy()


### PR DESCRIPTION
Fix #1359

Inspired by prior-art from videogular:

https://github.com/videogular/videogular/blob/master/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js#L698