### PR TITLE
Make pre-publish.js ES5 compatible

### DIFF
--- a/scripts/pre-publish.js
+++ b/scripts/pre-publish.js
@@ -5,8 +5,8 @@ const { default: players } = require('../lib/players')
 const generateSinglePlayers = async () => {
   for (const { key, name } of players) {
     const file = `
-      const createReactPlayer = require('./lib/ReactPlayer').createReactPlayer
-      const Player = require('./lib/players/${name}').default
+      var createReactPlayer = require('./lib/ReactPlayer').createReactPlayer
+      var Player = require('./lib/players/${name}').default
       module.exports = createReactPlayer([{
         key: '${key}',
         canPlay: Player.canPlay,


### PR DESCRIPTION
`pre-publish.js` injects code that circumvents webpack's `target` option. Meaning, if you specify in webpack `target = ['web', 'es5']` and are expecting an es5-compatible bundle, the bundle will be broken because of the `const` injected here; `const` is not es5.