### PR TITLE
update default HLS version to latest release

### DIFF
--- a/src/props.js
+++ b/src/props.js
@@ -169,7 +169,7 @@ export const defaultProps = {
       forceDASH: false,
       forceFLV: false,
       hlsOptions: {},
-      hlsVersion: '0.14.16',
+      hlsVersion: '1.1.4',
       dashVersion: '3.1.3',
       flvVersion: '1.5.0'
     },


### PR DESCRIPTION
This commit updates the default version of the HLS library to the latest release, v1.1.4 (https://github.com/video-dev/hls.js/releases/tag/v1.1.4). Until now, we were using a version dating back to Oct, 2020: https://github.com/video-dev/hls.js/releases/tag/v0.14.16.