### PR TITLE
ability to pass a component in light prop

### DIFF
--- a/src/Preview.js
+++ b/src/Preview.js
@@ -7,7 +7,8 @@ const cache = {}
 export default class Preview extends Component {
   mounted = false
   state = {
-    image: null
+    image: null,
+    previewImage: { isComponent: false, component: false }
   }
 
   componentDidMount () {
@@ -30,6 +31,10 @@ export default class Preview extends Component {
     if (typeof light === 'string') {
       this.setState({ image: light })
       return
+    }
+    if (typeof light !== "string" && typeof light !== "boolean") {
+      this.setState({ previewImage: { isComponent: true, component: light } });
+      return;
     }
     if (cache[url]) {
       this.setState({ image: cache[url] })
@@ -55,7 +60,7 @@ export default class Preview extends Component {
 
   render () {
     const { onClick, playIcon, previewTabIndex } = this.props
-    const { image } = this.state
+    const { image, previewImage } = this.state
     const flexCenter = {
       display: 'flex',
       alignItems: 'center',
@@ -65,7 +70,7 @@ export default class Preview extends Component {
       preview: {
         width: '100%',
         height: '100%',
-        backgroundImage: image ? `url(${image})` : undefined,
+        backgroundImage: image && !previewImage.isComponent ? `url(${image})` : undefined,
         backgroundSize: 'cover',
         backgroundPosition: 'center',
         cursor: 'pointer',
@@ -76,6 +81,8 @@ export default class Preview extends Component {
         borderRadius: ICON_SIZE,
         width: ICON_SIZE,
         height: ICON_SIZE,
+        position: previewImage.isComponent && 'absolute',
+        zIndex: 10,
         ...flexCenter
       },
       playIcon: {
@@ -99,6 +106,7 @@ export default class Preview extends Component {
         onKeyPress={this.handleKeyPress}
       >
         {playIcon || defaultPlayIcon}
+        {previewImage.isComponent && previewImage.component}
       </div>
     )
   }

--- a/src/Preview.js
+++ b/src/Preview.js
@@ -7,8 +7,7 @@ const cache = {}
 export default class Preview extends Component {
   mounted = false
   state = {
-    image: null,
-    previewImage: { isComponent: false, component: false }
+    image: null
   }
 
   componentDidMount () {
@@ -28,12 +27,11 @@ export default class Preview extends Component {
   }
 
   fetchImage ({ url, light, oEmbedUrl }) {
-    if (typeof light === 'string') {
-      this.setState({ image: light })
+    if (React.isValidElement(light)) {
       return
     }
-    if (React.isValidElement(light)) {
-      this.setState({ previewImage: { isComponent: true, component: light } })
+    if (typeof light === 'string') {
+      this.setState({ image: light })
       return
     }
     if (cache[url]) {
@@ -59,8 +57,9 @@ export default class Preview extends Component {
   }
 
   render () {
-    const { onClick, playIcon, previewTabIndex } = this.props
-    const { image, previewImage } = this.state
+    const { light, onClick, playIcon, previewTabIndex } = this.props
+    const { image } = this.state
+    const isElement = React.isValidElement(light)
     const flexCenter = {
       display: 'flex',
       alignItems: 'center',
@@ -70,7 +69,7 @@ export default class Preview extends Component {
       preview: {
         width: '100%',
         height: '100%',
-        backgroundImage: image && !previewImage.isComponent ? `url(${image})` : undefined,
+        backgroundImage: image && !isElement ? `url(${image})` : undefined,
         backgroundSize: 'cover',
         backgroundPosition: 'center',
         cursor: 'pointer',
@@ -81,7 +80,7 @@ export default class Preview extends Component {
         borderRadius: ICON_SIZE,
         width: ICON_SIZE,
         height: ICON_SIZE,
-        position: previewImage.isComponent && 'absolute',
+        position: isElement ? 'absolute' : undefined,
         ...flexCenter
       },
       playIcon: {
@@ -104,7 +103,7 @@ export default class Preview extends Component {
         tabIndex={previewTabIndex}
         onKeyPress={this.handleKeyPress}
       >
-        {previewImage.isComponent && previewImage.component}
+        {isElement ? light : null}
         {playIcon || defaultPlayIcon}
       </div>
     )

--- a/src/Preview.js
+++ b/src/Preview.js
@@ -32,9 +32,9 @@ export default class Preview extends Component {
       this.setState({ image: light })
       return
     }
-    if (typeof light !== "string" && typeof light !== "boolean") {
-      this.setState({ previewImage: { isComponent: true, component: light } });
-      return;
+    if (React.isValidElement(light)) {
+      this.setState({ previewImage: { isComponent: true, component: light } })
+      return
     }
     if (cache[url]) {
       this.setState({ image: cache[url] })
@@ -82,7 +82,6 @@ export default class Preview extends Component {
         width: ICON_SIZE,
         height: ICON_SIZE,
         position: previewImage.isComponent && 'absolute',
-        zIndex: 10,
         ...flexCenter
       },
       playIcon: {
@@ -105,8 +104,8 @@ export default class Preview extends Component {
         tabIndex={previewTabIndex}
         onKeyPress={this.handleKeyPress}
       >
-        {playIcon || defaultPlayIcon}
         {previewImage.isComponent && previewImage.component}
+        {playIcon || defaultPlayIcon}
       </div>
     )
   }

--- a/src/props.js
+++ b/src/props.js
@@ -17,7 +17,7 @@ export const propTypes = {
   playsinline: bool,
   pip: bool,
   stopOnUnmount: bool,
-  light: oneOfType([bool, string]),
+  light: oneOfType([bool, string, object]),
   playIcon: node,
   previewTabIndex: number,
   fallback: node,

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -37,7 +37,7 @@ export interface BaseReactPlayerProps {
   previewTabIndex?: number | null
   pip?: boolean
   stopOnUnmount?: boolean
-  light?: boolean | string
+  light?: boolean | string | ReactElement
   fallback?: ReactElement
   wrapper?: ComponentType<{ children: ReactNode }>
   onReady?: (player: ReactPlayer) => void


### PR DESCRIPTION
the light prop could be like this:
`light={<img style={{position: 'relative', width: '100%', height: '100%'}} src='https://media.nationalgeographic.org/assets/photos/000/290/29094.jpg' alt='sun' />}`

The styling of the image component should come from where it was called

The play icon will be positioned absolute if `light` is a component 

![image](https://user-images.githubusercontent.com/29911508/155490349-4cfc1373-f7dd-4044-84f9-24b654dd2fe7.png)

refers to #1320 