### PR TITLE
Add onSeek support for Youtube player

### DIFF
--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -131,7 +131,7 @@ export default class YouTube extends Component {
     if (data === CUED) onReady()
 
     // onSeek
-    this.handleOnSeek(data, onSeek)
+    if (onSeek) this.handleOnSeek(data, onSeek)
   };
 
   handleOnSeek (data, onSeek) {

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -45,37 +45,37 @@ export default class YouTube extends Component {
       return
     }
     getSDK(SDK_URL, SDK_GLOBAL, SDK_GLOBAL_READY, YT => YT.loaded).then(YT => {
-        if (!this.container) return
-        this.player = new YT.Player(this.container, {
-          width: '100%',
-          height: '100%',
-          videoId: id,
-          playerVars: {
-            autoplay: playing ? 1 : 0,
-            mute: muted ? 1 : 0,
-            controls: controls ? 1 : 0,
-            start: parseStartTime(url),
-            end: parseEndTime(url),
-            origin: window.location.origin,
-            playsinline: playsinline ? 1 : 0,
-            ...this.parsePlaylist(url),
-            ...playerVars
+      if (!this.container) return
+      this.player = new YT.Player(this.container, {
+        width: '100%',
+        height: '100%',
+        videoId: id,
+        playerVars: {
+          autoplay: playing ? 1 : 0,
+          mute: muted ? 1 : 0,
+          controls: controls ? 1 : 0,
+          start: parseStartTime(url),
+          end: parseEndTime(url),
+          origin: window.location.origin,
+          playsinline: playsinline ? 1 : 0,
+          ...this.parsePlaylist(url),
+          ...playerVars
+        },
+        events: {
+          onReady: () => {
+            if (loop) {
+              this.player.setLoop(true) // Enable playlist looping
+            }
+            this.props.onReady()
           },
-          events: {
-            onReady: () => {
-              if (loop) {
-                this.player.setLoop(true) // Enable playlist looping
-              }
-              this.props.onReady()
-            },
-            onPlaybackRateChange: event => this.props.onPlaybackRateChange(event.data),
-            onStateChange: this.onStateChange,
-            onError: event => onError(event.data)
-          },
-          host: MATCH_NOCOOKIE.test(url) ? NOCOOKIE_HOST : undefined,
-          ...embedOptions
-        })
-      }, onError)
+          onPlaybackRateChange: event => this.props.onPlaybackRateChange(event.data),
+          onStateChange: this.onStateChange,
+          onError: event => onError(event.data)
+        },
+        host: MATCH_NOCOOKIE.test(url) ? NOCOOKIE_HOST : undefined,
+        ...embedOptions
+      })
+    }, onError)
     if (embedOptions.events) {
       console.warn('Using `embedOptions.events` will likely break things. Use ReactPlayer’s callback props instead, eg onReady, onPlay, onPause')
     }
@@ -135,7 +135,7 @@ export default class YouTube extends Component {
   };
 
   handleOnSeek (data, onSeek) {
-    const { PLAYING, PAUSED, BUFFERING } = window[SDK_GLOBAL].PlayerState
+    const { PAUSED, BUFFERING } = window[SDK_GLOBAL].PlayerState
     // Update sequence with current state change event
     this._sequence = [...this._sequence, data]
     if (
@@ -151,9 +151,9 @@ export default class YouTube extends Component {
       onSeek(this.getCurrentTime()) // Arrow keys seek
       this._sequence = [] // Reset event sequence
     } else if (data === PAUSED) {
-      const seekTimer = setInterval(() => { // for every 750 ms check if paused and the time is changed  
-        if (                     
-          this.prevTime !== this.getCurrentTime() &&   // Paused seek
+      const seekTimer = setInterval(() => { // for every 750 ms check if paused and the time is changed
+        if (
+          this.prevTime !== this.getCurrentTime() && // Paused seek
           isSubArrayEnd(this._sequence, [PAUSED])
         ) {
           onSeek(this.getCurrentTime())

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -139,7 +139,7 @@ export default class YouTube extends Component {
     // Update sequence with current state change event
     this._sequence = [...this._sequence, data]
     if (
-      data == BUFFERING &&
+      data === BUFFERING &&
       isSubArrayEnd(this._sequence, [PAUSED, BUFFERING])
     ) {
       onSeek(this.getCurrentTime()) // Mouse seek
@@ -150,20 +150,25 @@ export default class YouTube extends Component {
     ) {
       onSeek(this.getCurrentTime()) // Arrow keys seek
       this._sequence = [] // Reset event sequence
+    } else if (data === PAUSED) {
+      const seekTimer = setInterval(() => { // for every 750 ms check if paused and the time is changed  
+        if (                     
+          this.prevTime !== this.getCurrentTime() &&   // Paused seek
+          isSubArrayEnd(this._sequence, [PAUSED])
+        ) {
+          onSeek(this.getCurrentTime())
+          // this._sequence = []
+          this.prevTime = this.getCurrentTime()
+        }
+      }, 750)
+      this._seekTimer = seekTimer
     } else {
       clearTimeout(this._timer) // Cancel previous event
+      clearInterval(this._seekTimer)
       if (data !== BUFFERING) {
         // If we're not buffering,
         const timeout = setTimeout(function () {
           // Start timer
-          if (                     
-            this.prevTime !== this.getCurrentTime &&   // Paused seek
-            // !isSubArrayEnd(this._sequence, [PAUSED]) && 
-            isSubArrayEnd(this._sequence, [PLAYING])
-          ) {
-            onSeek(this.getCurrentTime())
-            this._sequence = []
-          }
           this._sequence = [] // Reset event sequence
         }, 250)
         this._timer = timeout

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -131,7 +131,7 @@ export default class YouTube extends Component {
     if (data === CUED) onReady()
 
     // onSeek
-    this.handleOnSeek(data, BUFFERING, PAUSED, onSeek)
+    this.handleOnSeek(data, onSeek)
   };
 
   handleOnSeek (data, onSeek) {

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -138,7 +138,7 @@ export default class YouTube extends Component {
     // Update sequence with current state change event
     this._sequence = [...this._sequence, data]
     if (
-      data == BUFFERING &&
+      data === BUFFERING &&
       isSubArrayEnd(this._sequence, [PAUSED, BUFFERING])
     ) {
       onSeek(this.getCurrentTime()) // Mouse seek
@@ -149,6 +149,13 @@ export default class YouTube extends Component {
     ) {
       onSeek(this.getCurrentTime()) // Arrow keys seek
       this._sequence = [] // Reset event sequence
+    } else if (                     
+      this.prevTime !== this.getCurrentTime &&   // Paused seek
+      !isSubArrayEnd(this._sequence, [PAUSED]) &&
+      !isSubArrayEnd(this._sequence, [PLAYING])
+    ) {
+      onSeek(this.getCurrentTime())
+      this._sequence = []
     } else {
       clearTimeout(this._timer) // Cancel previous event
       if (data !== BUFFERING) {
@@ -160,6 +167,7 @@ export default class YouTube extends Component {
         this._timer = timeout
       }
     }
+    this.prevTime = this.getCurrentTime()
   }
 
   play () {

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -134,11 +134,12 @@ export default class YouTube extends Component {
     this.handleOnSeek(data, BUFFERING, PAUSED, onSeek)
   };
 
-  handleOnSeek (data, BUFFERING, PAUSED, onSeek) {
+  handleOnSeek (data, onSeek) {
+    const { PLAYING, PAUSED, BUFFERING } = window[SDK_GLOBAL].PlayerState
     // Update sequence with current state change event
     this._sequence = [...this._sequence, data]
     if (
-      data === BUFFERING &&
+      data == BUFFERING &&
       isSubArrayEnd(this._sequence, [PAUSED, BUFFERING])
     ) {
       onSeek(this.getCurrentTime()) // Mouse seek
@@ -149,19 +150,20 @@ export default class YouTube extends Component {
     ) {
       onSeek(this.getCurrentTime()) // Arrow keys seek
       this._sequence = [] // Reset event sequence
-    } else if (                     
-      this.prevTime !== this.getCurrentTime &&   // Paused seek
-      !isSubArrayEnd(this._sequence, [PAUSED]) &&
-      !isSubArrayEnd(this._sequence, [PLAYING])
-    ) {
-      onSeek(this.getCurrentTime())
-      this._sequence = []
     } else {
       clearTimeout(this._timer) // Cancel previous event
       if (data !== BUFFERING) {
         // If we're not buffering,
         const timeout = setTimeout(function () {
           // Start timer
+          if (                     
+            this.prevTime !== this.getCurrentTime &&   // Paused seek
+            // !isSubArrayEnd(this._sequence, [PAUSED]) && 
+            isSubArrayEnd(this._sequence, [PLAYING])
+          ) {
+            onSeek(this.getCurrentTime())
+            this._sequence = []
+          }
           this._sequence = [] // Reset event sequence
         }, 250)
         this._timer = timeout

--- a/src/utils.js
+++ b/src/utils.js
@@ -159,7 +159,7 @@ export function supportsWebKitPresentationMode (video = document.createElement('
   // Check if Safari supports PiP, and is not on mobile (other than iPad)
   // iPhone safari appears to "support" PiP through the check, however PiP does not function
   const notMobile = /iPhone|iPod/.test(navigator.userAgent) === false
-  return video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === 'function' && notMobile 
+  return video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === 'function' && notMobile
 }
 
 // for onSeekEvent on Youtube player

--- a/src/utils.js
+++ b/src/utils.js
@@ -159,5 +159,16 @@ export function supportsWebKitPresentationMode (video = document.createElement('
   // Check if Safari supports PiP, and is not on mobile (other than iPad)
   // iPhone safari appears to "support" PiP through the check, however PiP does not function
   const notMobile = /iPhone|iPod/.test(navigator.userAgent) === false
-  return video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === 'function' && notMobile
+  return video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === 'function' && notMobile 
+}
+
+// for onSeekEvent on Youtube player
+export function isSubArrayEnd (A, B) {
+  if (A.length < B.length) return false
+  let i = 0
+  while (i < B.length) {
+    if (A[A.length - i - 1] !== B[B.length - i - 1]) return false
+    i++
+  }
+  return true
 }


### PR DESCRIPTION
Hello.
Im making a "watch together" app and the "onSeek" event for youtube is not working.
I found this tutorial on google: https://simplernerd.com/js-youtube-seek/
i thought it would help other developer if they are using the player.

I just added a little code to the tutorial to detect seek when the player is paused.

    else if (data === PAUSED) {    
        const seekTimer = setInterval(() => {  
            if (                     
              this.prevTime !== this.getCurrentTime() &&   // Paused seek
              isSubArrayEnd(this._sequence, [PAUSED])
            ) {
              onSeek(this.getCurrentTime())
              // this._sequence = []
              this.prevTime = this.getCurrentTime()
            }
         }, 750)
    }
Implements the `onSeek` event for YouTube. Fixes https://github.com/cookpete/react-player/issues/1243
