### PR TITLE
Add flvjs error handling, pass it to props onError method.

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -196,6 +196,9 @@ export default class FilePlayer extends Component {
       getSDK(FLV_SDK_URL.replace('VERSION', flvVersion), FLV_GLOBAL).then(flvjs => {
         this.flv = flvjs.createPlayer({ type: 'flv', url })
         this.flv.attachMediaElement(this.player)
+        this.flv.on(flvjs.Events.ERROR, (e, data) => {
+          this.props.onError(e, data, this.flv, flvjs)
+        })
         this.flv.load()
         this.props.onLoaded()
       })

--- a/test/players/FilePlayer.js
+++ b/test/players/FilePlayer.js
@@ -102,6 +102,45 @@ test('onError - hls', t => {
   })
 })
 
+test('onError - flv', t => {
+  return new Promise(resolve => {
+    const onError = () => {
+      t.pass()
+      resolve()
+    }
+
+    class FlvPlayer {
+      attachMediaElement () {
+
+      };
+
+      on = (event, cb) => {
+        if (event === 'error') {
+          setTimeout(cb, 100)
+        }
+      };
+
+      load = () => {}
+    }
+
+    class flvjs {
+      static Events = { ERROR: 'error' }
+
+      loadSource = () => null
+      attachMedia = () => null
+      static createPlayer = () => new FlvPlayer()
+    }
+    const url = 'file.flv'
+    const getSDK = sinon.stub(utils, 'getSDK').resolves(flvjs)
+    const onLoaded = () => null
+    const instance = shallow(
+      <FilePlayer url={url} config={config} onLoaded={onLoaded} onError={onError} />
+    ).instance()
+    instance.load(url)
+    getSDK.restore()
+  })
+})
+
 test('load - dash', async t => {
   const dashjs = {
     MediaPlayer: () => ({


### PR DESCRIPTION
When flvjs instance emits error it is not passed to the react player instance.

**Expected behavior**

Error should be passed to _onError_ handler

**Steps to Reproduce**

```
git clone https://github.com/CookPete/react-player.git
cd react-player
npm install # or yarn
npm start
open http://localhost:3000
```

In _Custom URL_ write **file.flv**

```
> events.js:62 Uncaught (in promise) Error: Uncaught, unspecified "error" event. (NetworkError)
    at i.emit (events.js:62:1)
    at i.<anonymous> (flv-player.js:236:27)
    at i.emit (events.js:84:1)
    at transmuxer.js:189:27
 ```
 
 **After fix**
 
 ```
> onError NetworkError
```