### PR TITLE
Add Support for YouTube Short Urls

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -1,6 +1,6 @@
 import { isMediaStream, isBlobUrl } from './utils'
 
-export const MATCH_URL_YOUTUBE = /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/(?:embed\/|v\/|watch\/|watch\?v=|watch\?.+&v=))((\w|-){11})|youtube\.com\/playlist\?list=|youtube\.com\/user\//
+export const MATCH_URL_YOUTUBE = /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/(?:embed\/|v\/|watch\/|watch\?v=|watch\?.+&v=|shorts\/))((\w|-){11})|youtube\.com\/playlist\?list=|youtube\.com\/user\//
 export const MATCH_URL_SOUNDCLOUD = /(?:soundcloud\.com|snd\.sc)\/[^.]+$/
 export const MATCH_URL_VIMEO = /vimeo\.com\/(?!progressive_redirect).+/
 export const MATCH_URL_FACEBOOK = /^https?:\/\/(www\.)?facebook\.com.*\/(video(s)?|watch|story)(\.php?|\/).+$/

--- a/test/ReactPlayer/staticMethods.js
+++ b/test/ReactPlayer/staticMethods.js
@@ -11,6 +11,7 @@ configure({ adapter: new Adapter() })
 
 test('canPlay()', t => {
   t.true(ReactPlayer.canPlay('https://www.youtube.com/watch?v=oUFJJNQGwhk'))
+  t.true(ReactPlayer.canPlay('https://youtube.com/shorts/370kwJ-x5TY?feature=share'))
   t.true(ReactPlayer.canPlay('https://soundcloud.com/miami-nights-1984/accelerated'))
   t.true(ReactPlayer.canPlay('https://www.facebook.com/facebook/videos/10153231379946729'))
   t.true(ReactPlayer.canPlay('https://vimeo.com/90509568'))


### PR DESCRIPTION
Updates the YouTube pattern to recognize the YouTube short share url to retrieve the id.

Fixes [1427](https://github.com/cookpete/react-player/issues/1427) 