### PR TITLE
Fix onProgress not firing in Strict Mode

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -90,7 +90,10 @@ export default class Player extends Component {
   }
 
   handlePlayerMount = player => {
-    if (this.player) return // Prevent loading twice in strict mode
+    if (this.player) { // Prevent loading twice in strict mode
+      this.progress()
+      return
+    }
     this.player = player
     this.player.load(this.props.url)
     this.progress()

--- a/src/Player.js
+++ b/src/Player.js
@@ -90,9 +90,9 @@ export default class Player extends Component {
   }
 
   handlePlayerMount = player => {
-    if (this.player) { // Prevent loading twice in strict mode
-      this.progress()
-      return
+    if (this.player) {
+      this.progress() // Ensure onProgress is still called in strict mode
+      return // Return here to prevent loading twice in strict mode
     }
     this.player = player
     this.player.load(this.props.url)

--- a/test/Player.js
+++ b/test/Player.js
@@ -154,6 +154,25 @@ test('progress()', t => {
   }))
 })
 
+test('progress() handlePlayerMount', t => {
+  const load = sinon.fake()
+  const onProgress = sinon.fake()
+  const instance = shallow(<Player url='file.mp4' onProgress={onProgress} />).instance()
+  instance.isReady = true
+  instance.handlePlayerMount({
+    load,
+    getCurrentTime: sinon.fake.returns(10),
+    getSecondsLoaded: sinon.fake.returns(20),
+    getDuration: sinon.fake.returns(40)
+  })
+  t.true(onProgress.calledWith({
+    loaded: 0.5,
+    loadedSeconds: 20,
+    played: 0.25,
+    playedSeconds: 10
+  }))
+})
+
 test('seekTo() - seconds', t => {
   const load = sinon.fake()
   const seekTo = sinon.fake()


### PR DESCRIPTION
- Update the Player handlePlayerMount method so that the progress
  method is always called.

Should fix #1453 

let me know if that test makes sense or not.