### PR TITLE
Add `"sideEffects": false` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,5 +151,6 @@
   },
   "auto-changelog": {
     "breakingPattern": "Breaking changes:"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
I'm using this package as a dependency, and I want Webpack to be able to [optimize it out automatically](https://webpack.js.org/configuration/optimization/#optimizationsideeffects) if it ends up being the case that I do not use it (or only use parts of it).

Skimming through the source code, I don't see any of the files running any code as the files are loaded, which should mean that the project qualifies as being side-effect free and can be optimized by Webpack.