### PR TITLE
responsive CSS fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ class ResponsivePlayer extends Component {
 ```css
 .player-wrapper {
   position: relative;
-  padding-top: 56.25% /* Player ratio: 100 / (1280 / 720) */
+  padding-top: 56.25%; /* Player ratio: 100 / (1280 / 720) */
 }
 
 .react-player {


### PR DESCRIPTION
Hi, your player is great, thank you! I found a syntax error that breaks some of the responsive CSS. This tiny edit -- adding a single semicolon to one line of CSS -- fixes the problem. Thank you for considering this pull request.