### PR TITLE
DRM Support

### DIFF
--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -436,7 +436,7 @@ class App extends Component {
               </tr>
 
               <tr>
-                <th>Widevine DRM <br/>(Not work in Safari)</th>
+                <th>Widevine DRM <br />(Not work in Safari)</th>
                 <td>
                   {this.renderLoadButton('https://cdn.bitmovin.com/content/assets/art-of-motion_drm/mpds/11331.mpd', 'ShakaPlayer', {
                     ...config,
@@ -480,7 +480,7 @@ class App extends Component {
               </tr>
 
               <tr>
-                <th>Fairplay DRM <br/>(Only in Safari)</th>
+                <th>Fairplay DRM <br />(Only in Safari)</th>
                 <td>
                   {this.renderLoadButton('', 'ShakaPlayer', {
                     ...config,
@@ -488,9 +488,7 @@ class App extends Component {
                       ...config.file,
                       useShakaforHLS: true,
                       dashProtectionData: {},
-                      shakaOptions: {
-
-                      }
+                      shakaOptions: {}
                     }
                   })}
                 </td>

--- a/src/props.js
+++ b/src/props.js
@@ -60,7 +60,15 @@ export const propTypes = {
       hlsOptions: object,
       hlsVersion: string,
       dashVersion: string,
-      flvVersion: string
+      flvVersion: string,
+      dashOptions: object,
+      dashProtectionData: object,
+      useShakaforDASH: bool,
+      useShakaforHLS: bool,
+      shakaOptions: object,
+      shakaVersion: string,
+      shakaNetworkFilters: func,
+      debug: bool
     }),
     wistia: shape({
       options: object,
@@ -169,9 +177,17 @@ export const defaultProps = {
       forceDASH: false,
       forceFLV: false,
       hlsOptions: {},
-      hlsVersion: '1.1.4',
-      dashVersion: '3.1.3',
-      flvVersion: '1.5.0'
+      hlsVersion: '1.2.4',
+      dashVersion: '3.2.2',
+      flvVersion: '1.5.0',
+      dashOptions: {},
+      dashProtectionData: {},
+      useShakaforDASH: false,
+      useShakaforHLS: false,
+      shakaOptions: {},
+      shakaVersion: '3.3.9',
+      shakaNetworkFilters: null,
+      debug: false
     },
     wistia: {
       options: {},

--- a/test/players/FilePlayer.js
+++ b/test/players/FilePlayer.js
@@ -454,13 +454,13 @@ test('clear srcObject on url change', t => {
 test('load - shaka - hls', async (t) => {
   class Player {
     attach = async () => null;
+    resetConfiguration = () => null;
+    configure = () => null;
+    load = async () => null;
     getNetworkingEngine = () => ({
       clearAllResponseFilters: () => null,
       clearAllRequestFilters: () => null
     })
-
-    confgure = () => null;
-    load = async () => null;
   }
 
   const Shaka = {
@@ -495,14 +495,13 @@ test('load - shaka - hls', async (t) => {
 test('load - shaka - dash', async (t) => {
   class Player {
     attach = async () => null;
+    resetConfiguration = () => null;
+    configure = () => null;
+    load = async () => null;
     getNetworkingEngine = () => ({
       clearAllResponseFilters: () => null,
       clearAllRequestFilters: () => null
     })
-
-    resetConfiguration = () => null
-    configure = () => null;
-    load = async () => null;
   }
 
   const Shaka = {

--- a/test/players/FilePlayer.js
+++ b/test/players/FilePlayer.js
@@ -147,6 +147,13 @@ test('load - dash', async t => {
       create: () => ({
         on: () => null,
         initialize: () => null,
+        attachView: () => null,
+        setAutoPlay: () => null,
+        attachSource: () => null,
+        setProtectionData: () => null,
+        getProtectionController: () => ({
+          setRobustnessLevel: () => null
+        }),
         getDebug: () => ({
           setLogToBrowserConsole: () => null
         }),
@@ -442,4 +449,87 @@ test('clear srcObject on url change', t => {
   instance.load(url)
   wrapper.setProps({ url: 'file.mpv' })
   t.is(instance.player.srcObject, null)
+})
+
+test('load - shaka - hls', async (t) => {
+  class Player {
+    attach = async () => null;
+    getNetworkingEngine = () => ({
+      clearAllResponseFilters: () => null,
+      clearAllRequestFilters: () => null
+    })
+
+    confgure = () => null;
+    load = async () => null;
+  }
+
+  const Shaka = {
+    log: {
+      setLevel: () => null,
+      Level: {
+        NONE: null
+      }
+    },
+    polyfill: {
+      installAll: () => null
+    },
+    Player
+  }
+
+  const updatedConfig = {
+    ...config,
+    useShakaforHLS: true
+  }
+
+  const url = 'file.m3u8'
+  const getSDK = sinon.stub(utils, 'getSDK').resolves(Shaka)
+  const onLoaded = () => t.pass()
+  const instance = shallow(
+    <FilePlayer url={url} config={updatedConfig} onLoaded={onLoaded} />
+  ).instance()
+  instance.load(url)
+  t.true(getSDK.calledOnce)
+  getSDK.restore()
+})
+
+test('load - shaka - dash', async (t) => {
+  class Player {
+    attach = async () => null;
+    getNetworkingEngine = () => ({
+      clearAllResponseFilters: () => null,
+      clearAllRequestFilters: () => null
+    })
+
+    resetConfiguration = () => null
+    configure = () => null;
+    load = async () => null;
+  }
+
+  const Shaka = {
+    log: {
+      setLevel: () => null,
+      Level: {
+        NONE: null
+      }
+    },
+    polyfill: {
+      installAll: () => null
+    },
+    Player
+  }
+
+  const updatedConfig = {
+    ...config,
+    useShakaforDASH: true
+  }
+
+  const url = 'file.mpd'
+  const getSDK = sinon.stub(utils, 'getSDK').resolves(Shaka)
+  const onLoaded = () => t.pass()
+  const instance = shallow(
+    <FilePlayer url={url} config={updatedConfig} onLoaded={onLoaded} />
+  ).instance()
+  instance.load(url)
+  t.true(getSDK.calledOnce)
+  getSDK.restore()
 })

--- a/types/file.d.ts
+++ b/types/file.d.ts
@@ -20,6 +20,14 @@ export interface FileConfig {
   hlsVersion?: string
   dashVersion?: string
   flvVersion?: string
+  dashOptions?: Record<string, any>
+  dashProtectionData: Record<string, any>
+  useShakaforDASH?:boolean
+  useShakaforHLS?:boolean
+  shakaOptions?: Record<string, any>
+  shakaVersion?: string
+  shakaNetworkFilters?: (engine: any) => void;
+  debug: boolean
 }
 
 export interface FilePlayerProps extends BaseReactPlayerProps {


### PR DESCRIPTION
Hello everyone, 

I have added the support for DRM Content using Shaka or DASH.IF. 

Following are new configurations: 
```
dashOptions: {}, 
dashProtectionData: {},
useShakaforDASH: false,
useShakaforHLS: false,
shakaOptions: {},
shakaVersion: '3.3.9',
shakaNetworkFilters: null,
debug: false
````
**dashOptions**: user can pass all the DASH.IF configurations. provided in [Dash Settings](http://cdn.dashjs.org/latest/jsdoc/module-Settings.html)

**dashProtectionData** DASH.IF DRM settings. [examples](https://github.com/Dash-Industry-Forum/dash.js/tree/development/samples/drm)

**useShakaforDASH** for user want to use ShakaPlayer for playing DASH(mpd) files & not want to use DASH.IF

**useShakaforHLS** for user want to user ShakaPlayer for playing HLS(m3u8) files & not want to use HLS.js

**shakaOptions** Shaka player [configurations](https://shaka-player-demo.appspot.com/docs/api/tutorial-config.html)

**shakaVersion** this version is stable, and don't have issues of playing fairplay content in safari. 

**shakaNetworkFilters** this is function callback, user will be given Shaka.NetworkEngine() instance and use it to wrap license requests & response as needed by some FairPlay for Widevine. [linkk](https://shaka-player-demo.appspot.com/docs/api/tutorial-license-wrapping.html)

**debug** if true then which ever library in use, HLS.js or DASH.IF or ShakaPlayer it will enable debug logs for these. 

I didn't find any fairplay sample stream to put in demo app. If anyone can provide, I'll update it. 

This is my first contribution to any open source project. Hoping that it will pass. 

Regards, 

Ahsan.
