### PR TITLE
add unbundled es6 build with jsx file extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ package-lock.json
 /lazy
 /demo
 /coverage
+/es6
 .idea/
 .vscode/

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A React component for playing a variety of URLs, including file paths, YouTube, Facebook, Twitch, SoundCloud, Streamable, Vimeo, Wistia and DailyMotion",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "module": "es6/index.js",
   "scripts": {
     "clean": "rimraf lib lazy demo coverage *.d.ts",
     "start": "webpack-dev-server --config webpack/config.babel.js",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:es6": "rsync --exclude demo -r ./src/ ./es6/ && find ./es6/ -name '*.js' -exec grep -q 'import React' {} \\; -exec mv {} {}x \\;",
     "preversion": "npm run lint && npm run test",
     "version": "auto-changelog -p && npm run build:dist && npm run build:standalone && git add CHANGELOG.md dist",
-    "prepublishOnly": "npm run build:lib && npm run build:lazy && npm run build:dist && node scripts/pre-publish.js && cp -r types/* .",
+    "prepublishOnly": "npm run build:lib && npm run build:lazy && npm run build:dist && npm run build:es6 && node scripts/pre-publish.js && cp -r types/* .",
     "postpublish": "node scripts/post-publish.js && npm run clean"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:demo": "cross-env NODE_ENV=production webpack --config webpack/production.babel.js",
     "build:dist": "cross-env NODE_ENV=production webpack --config webpack/dist.babel.js",
     "build:standalone": "cross-env NODE_ENV=production webpack --config webpack/standalone.babel.js && node scripts/standalone-es6.js",
+    "build:es6": "rsync --exclude demo -r ./src/ ./es6/ && find ./es6/ -name '*.js' -exec grep -q 'import React' {} \\; -exec mv {} {}x \\;",
     "preversion": "npm run lint && npm run test",
     "version": "auto-changelog -p && npm run build:dist && npm run build:standalone && git add CHANGELOG.md dist",
     "prepublishOnly": "npm run build:lib && npm run build:lazy && npm run build:dist && node scripts/pre-publish.js && cp -r types/* .",


### PR DESCRIPTION
Fixes: https://github.com/cookpete/react-player/issues/1443

This command copies the src files to a directory called 'es6', excluding the demo directory, and renames 'js' files to 'jsx' files if they use jsx. This can then be imported into a project that uses vite this way:

```js
import ReactPlayer from 'react-player/es6'; 
```

This should allow lazy imports as well. 

Perhaps the readme should be updated? Not sure what exactly to write.