### PR TITLE
fix: empty src attr in StrictMode

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -91,6 +91,7 @@ export default class Player extends Component {
 
   handlePlayerMount = player => {
     if (this.player) {
+      this.player.load(this.props.url) // Ensure load is still called in strict mode
       this.progress() // Ensure onProgress is still called in strict mode
       return // Return here to prevent loading twice in strict mode
     }

--- a/src/Player.js
+++ b/src/Player.js
@@ -91,7 +91,6 @@ export default class Player extends Component {
 
   handlePlayerMount = player => {
     if (this.player) {
-      this.player.load(this.props.url) // Ensure load is still called in strict mode
       this.progress() // Ensure onProgress is still called in strict mode
       return // Return here to prevent loading twice in strict mode
     }

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -155,6 +155,10 @@ export default class FilePlayer extends Component {
 
   load (url) {
     const { hlsVersion, hlsOptions, dashVersion, flvVersion } = this.props.config
+    // In development with StrictMode enabled, component went throught his lifecycle twice
+    // But we empty src in componentWillUnmount, which called after two render methods
+    // So we need to ensure src has desired value
+    this.player.src = this.getSource(url)
     if (this.hls) {
       this.hls.destroy()
     }

--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -23,6 +23,7 @@ export default class FilePlayer extends Component {
   componentDidMount () {
     this.props.onMount && this.props.onMount(this)
     this.addListeners(this.player)
+    this.player.src = this.getSource(this.props.url) // Ensure src is set in strict mode
     if (IS_IOS) {
       this.player.load()
     }
@@ -155,10 +156,6 @@ export default class FilePlayer extends Component {
 
   load (url) {
     const { hlsVersion, hlsOptions, dashVersion, flvVersion } = this.props.config
-    // In development with StrictMode enabled, component went throught his lifecycle twice
-    // But we empty src in componentWillUnmount, which called after two render methods
-    // So we need to ensure src has desired value
-    this.player.src = this.getSource(url)
     if (this.hls) {
       this.hls.destroy()
     }


### PR DESCRIPTION
* Update the Player handlePlayerMount method so that the progress load is always called.
* Update the FilePlayer load method so that the src attribute always filled with value
This should fix #1530 #1520 #1508 