### PR TITLE
Replace Vimeo default preview thumbnail

### DIFF
--- a/src/Preview.js
+++ b/src/Preview.js
@@ -43,7 +43,7 @@ export default class Preview extends Component {
       .then(response => response.json())
       .then(data => {
         if (data.thumbnail_url && this.mounted) {
-          const image = data.thumbnail_url.replace('height=100', 'height=480')
+          const image = data.thumbnail_url.replace('height=100', 'height=480').replace('-d_295x166', '-d_640')
           this.setState({ image })
           cache[url] = image
         }


### PR DESCRIPTION
Replace Vimeo default preview thumbnail size from 295x166 to 640

https://developer.vimeo.com/api/common-formats