### PR TITLE
Declare standalone.js uses side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,5 +153,7 @@
   "auto-changelog": {
     "breakingPattern": "Breaking changes:"
   },
-  "sideEffects": false
+  "sideEffects": [
+    "./src/standalone.js"
+  ]
 }


### PR DESCRIPTION
Fixes #1584 

This is an update to PR https://github.com/cookpete/react-player/pull/1524 since `src/standalone.js` does indeed use side effects.

Working fiddle with `standalone.js` generated with change: https://jsfiddle.net/melotte/wmn3tbca/
