### PR TITLE
Added Vimeo Muteability for iOS

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -94,6 +94,10 @@ export default class Vimeo extends Component {
     this.callPlayer('setVolume', fraction)
   }
 
+  setMuted (muted) {
+    this.callPlayer('setMuted', muted)
+  }
+
   setLoop (loop) {
     this.callPlayer('setLoop', loop)
   }
@@ -103,13 +107,11 @@ export default class Vimeo extends Component {
   }
 
   mute = () => {
-    this.setVolume(0)
+    this.setMuted(true)
   }
 
   unmute = () => {
-    if (this.props.volume !== null) {
-      this.setVolume(this.props.volume)
-    }
+    this.setMuted(false)
   }
 
   getDuration () {


### PR DESCRIPTION
Vimeo now has `getMuted` and `setMuted` methods, so we don't need to rely on setting the volume. https://github.com/vimeo/player.js#setmutedmuted-boolean-promiseboolean-error