### PR TITLE
Fix #1604 - FilePlayer does not work if I passed an array of urls

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -41,7 +41,8 @@ export default class FilePlayer extends Component {
 
     if (
       this.props.url !== prevProps.url &&
-      !isMediaStream(this.props.url)
+      !isMediaStream(this.props.url) &&
+      !(this.props.url instanceof Array) // Avoid infinite loop
     ) {
       this.player.srcObject = null
     }


### PR DESCRIPTION
# This PR aims to fix [FilePlayer does not work if I passed an array of urls #1604](https://github.com/cookpete/react-player/issues/1604)

PR #1538 was setting the src of the video element to undefined. Because of this, even if the users passed an array of urls, the video element would not play because it got an `src` of `undefined`;

After fixing the undefined `src` issue, another PR was making an infinite loop issue when the user passed an array of URLs. There, the author set the `srcObject` to null. There as well, a check for `url` prop was missing.

This PR aims to fix both of these overlooked aspects.