### PR TITLE
Add keepPlaying to seekTo

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -144,7 +144,7 @@ export default class Player extends Component {
     this.progressTimeout = setTimeout(this.progress, this.props.progressFrequency || this.props.progressInterval)
   }
 
-  seekTo (amount, type) {
+  seekTo (amount, type, keepPlaying = false) {
     // When seeking before player is ready, store value and seek later
     if (!this.isReady) {
       if (amount !== 0) {
@@ -161,10 +161,10 @@ export default class Player extends Component {
         console.warn('ReactPlayer: could not seek using fraction – duration not yet available')
         return
       }
-      this.player.seekTo(duration * amount)
+      this.player.seekTo(duration * amount, keepPlaying)
       return
     }
-    this.player.seekTo(amount)
+    this.player.seekTo(amount, keepPlaying)
   }
 
   handleReady = () => {

--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -98,9 +98,9 @@ export const createReactPlayer = (players, fallback) => {
       return this.player.getInternalPlayer(key)
     }
 
-    seekTo = (fraction, type) => {
+    seekTo = (fraction, type, keepPlaying) => {
       if (!this.player) return null
-      this.player.seekTo(fraction, type)
+      this.player.seekTo(fraction, type, keepPlaying)
     }
 
     handleReady = () => {

--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -143,9 +143,9 @@ export default class YouTube extends Component {
     this.callPlayer('stopVideo')
   }
 
-  seekTo (amount) {
+  seekTo (amount, keepPlaying) {
     this.callPlayer('seekTo', amount)
-    if (!this.props.playing) {
+    if (!keepPlaying && !this.props.playing) {
       this.pause()
     }
   }


### PR DESCRIPTION
I just added the option to the Youtube player as that is the only one that has a pause on the seekTo.

Made it default to false so that it does not alter any behaviour that is counting on that pause.

Let me know if the other players should have the same option or not. If so, would it be better to keep them as true since it didn't have a behaviour of pause before?