### PR TITLE
fix: default player src to empty string to avoid unwanted network requests when using HLS content.

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -24,7 +24,7 @@ export default class FilePlayer extends Component {
   componentDidMount () {
     this.props.onMount && this.props.onMount(this)
     this.addListeners(this.player)
-    this.player.src = this.getSource(this.props.url) // Ensure src is set in strict mode
+    this.player.src = this.getSource(this.props.url) || '' // Ensure src is set in strict mode
     if (IS_IOS) {
       this.player.load()
     }


### PR DESCRIPTION
**Issue:**

https://github.com/cookpete/react-player/issues/1598

[This](https://github.com/cookpete/react-player/blob/master/src/players/FilePlayer.js#L27) line is causing unwanted network requests when using a hls source. This line sets the active player `src` to undefined which gets set on the underlying video element as `src="undefined"` this then generates the network requests mentioned above as this defaults to `https://CURRENT_URL/undefined`.


<img width="1412" alt="Screenshot 2023-04-26 at 19 07 01" src="https://user-images.githubusercontent.com/7782211/234665031-3665065a-dd13-4b66-bdee-58e5cad80725.png">


**Fix:**

Default to setting this.player.src as an empty string if the source value is undefined on mount. This is the case when using hls, dash or other media streams. See [here](https://github.com/cookpete/react-player/blob/master/src/players/FilePlayer.js#L320). By defaulting the src value in this case to a empty string the src property gets set on the `video` element as `<video src />`, not ideal but better than `<video src="undefined" />` and it doesn't make any unwanted requests. In the case of HLS streams the HLS package then takes control of this element and loading the actual source anyway.

I tested this by overwriting `this.player.src` to the empty string after it's been set to undefined in the breakpoint above. Seems to work ok and no unwanted network requests being fired.

I was initially going to do this instead:

```
    const source = this.getSource(this.props.url);
    if (source) {
      this.player.src = source;
    }
```

However I noted the comment about strict mode and ensuring the src value is set.

