### PR TITLE
Deno compatibility

### DIFF
--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -9,7 +9,7 @@ import Player from './Player'
 
 const Preview = lazy(() => import(/* webpackChunkName: 'reactPlayerPreview' */'./Preview'))
 
-const IS_BROWSER = typeof window !== 'undefined' && window.document
+const IS_BROWSER = typeof window !== 'undefined' && window.document && typeof document !== 'undefined'
 const IS_GLOBAL = typeof global !== 'undefined' && global.window && global.window.document
 const SUPPORTED_PROPS = Object.keys(propTypes)
 


### PR DESCRIPTION
Draft/suggestion for #1631. The `typeof document` check is needed for Deno environments, as `window` is part of the runtime API.