### PR TITLE
Media can not be played if `url` is an array for the file player

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -24,7 +24,10 @@ export default class FilePlayer extends Component {
   componentDidMount () {
     this.props.onMount && this.props.onMount(this)
     this.addListeners(this.player)
-    this.player.src = this.getSource(this.props.url) // Ensure src is set in strict mode
+    const src = this.getSource(this.props.url) // Ensure src is set in strict mode
+    if (src) {
+      this.player.src = src
+    }
     if (IS_IOS || this.props.config.forceDisableHls) {
       this.player.load()
     }
@@ -45,7 +48,7 @@ export default class FilePlayer extends Component {
   }
 
   componentWillUnmount () {
-    this.player.src = ''
+    this.player.removeAttribute('src')
     this.removeListeners(this.player)
     if (this.hls) {
       this.hls.destroy()


### PR DESCRIPTION
If the `url` is an array, and the player is a file player, the `src` property will become `"undefined"`, this will trigger an error and cause the media unable to be played.

![image](https://github.com/cookpete/react-player/assets/1384036/57886a76-c6e4-440f-9805-62abf246e68b)
