### PR TITLE
tools: patch Webpack Node.js >= 17 hash issue

### DIFF
--- a/webpack/config.babel.js
+++ b/webpack/config.babel.js
@@ -99,3 +99,6 @@ export default {
     hints: false
   }
 }
+const crypto = require('crypto')
+const cryptoOrigCreateHash = crypto.createHash
+crypto.createHash = algorithm => cryptoOrigCreateHash(algorithm === 'md4' ? 'sha256' : algorithm)

--- a/webpack/dist.babel.js
+++ b/webpack/dist.babel.js
@@ -28,3 +28,6 @@ export default {
     })
   ]
 }
+const crypto = require('crypto')
+const cryptoOrigCreateHash = crypto.createHash
+crypto.createHash = algorithm => cryptoOrigCreateHash(algorithm === 'md4' ? 'sha256' : algorithm)

--- a/webpack/production.babel.js
+++ b/webpack/production.babel.js
@@ -22,3 +22,6 @@ export default {
     ]
   }
 }
+const crypto = require('crypto')
+const cryptoOrigCreateHash = crypto.createHash
+crypto.createHash = algorithm => cryptoOrigCreateHash(algorithm === 'md4' ? 'sha256' : algorithm)

--- a/webpack/standalone.babel.js
+++ b/webpack/standalone.babel.js
@@ -25,3 +25,6 @@ export default {
     })
   ]
 }
+const crypto = require('crypto')
+const cryptoOrigCreateHash = crypto.createHash
+crypto.createHash = algorithm => cryptoOrigCreateHash(algorithm === 'md4' ? 'sha256' : algorithm)


### PR DESCRIPTION
Piggy backing off https://github.com/cookpete/react-player/pull/1664

This monkey patch of crypto seems like a good fix until the build tools will be changed / upgraded.
