### PR TITLE
Fix #1692: Error event not triggering when using array of urls

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -330,11 +330,19 @@ export default class FilePlayer extends Component {
     return url
   }
 
+  // As errors on the `source` tag does not trigger the error event of the
+  // parent video/audio tag (player). We have to manully trigger
+  // the players error event.
+  handleSourceError = () => {
+    const event = new Event('error', { bubbles: true })
+    this.player.dispatchEvent(event)
+  }
+
   renderSourceElement = (source, index) => {
     if (typeof source === 'string') {
-      return <source key={index} src={source} />
+      return <source key={index} src={source} onError={this.handleSourceError} />
     }
-    return <source key={index} {...source} />
+    return <source key={index} {...source} onError={this.handleSourceError} />
   }
 
   renderTrack = (track, index) => {


### PR DESCRIPTION
Aims to fix issue: #1692 
For array of URLs, we are rendering `<source />` tags. Errors on these tags do not trigger the parent players error event. So created a `handleSourceError` function which simply creates an `Error event` and dispatches that event on the player.