### PR TITLE
docs: fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,9 @@
 </h1>
 
 <p align='center'>
-  <a href='https://www.npmjs.com/package/react-player'>
-    <img src='https://img.shields.io/npm/v/react-player.svg' alt='Latest npm version'>
-  </a>
-  <a href='https://codecov.io/gh/CookPete/react-player'>
-    <img src='https://img.shields.io/codecov/c/github/cookpete/react-player.svg' alt='Test Coverage'>
-  </a>
-  <a href='https://www.patreon.com/cookpete'>
-    <img src='https://img.shields.io/badge/sponsor-patreon-fa6854.svg' alt='Become a sponsor on Patreon'>
-  </a>
+  <a href='https://www.npmjs.com/package/react-player'><img src='https://img.shields.io/npm/v/react-player.svg' alt='Latest npm version'></a>
+  <a href='https://codecov.io/gh/CookPete/react-player'><img src='https://img.shields.io/codecov/c/github/cookpete/react-player.svg' alt='Test Coverage'></a>
+  <a href='https://www.patreon.com/cookpete'><img src='https://img.shields.io/badge/sponsor-patreon-fa6854.svg' alt='Become a sponsor on Patreon'></a>
 </p>
 
 <p align='center'>


### PR DESCRIPTION
Remove unwanted underline between shield badges.

Possibly a result of how line endings are handled in github flavored markdown

The issue:
![image](https://github.com/cookpete/react-player/assets/68184623/a9b1ccf8-d50c-4eec-8a93-720363438e27)

The fix:
![image](https://github.com/cookpete/react-player/assets/68184623/9d153d85-9e12-4b94-9c78-a765ab97a94f)

