### PR TITLE
feat: add Mux + hls.js support back in

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -3,7 +3,8 @@ import { isMediaStream, isBlobUrl } from './utils'
 export const MATCH_URL_YOUTUBE = /(?:youtu\.be\/|youtube(?:-nocookie|education)?\.com\/(?:embed\/|v\/|watch\/|watch\?v=|watch\?.+&v=|shorts\/|live\/))((\w|-){11})|youtube\.com\/playlist\?list=|youtube\.com\/user\//
 export const MATCH_URL_SOUNDCLOUD = /(?:soundcloud\.com|snd\.sc)\/[^.]+$/
 export const MATCH_URL_VIMEO = /vimeo\.com\/(?!progressive_redirect).+/
-export const MATCH_URL_MUX = /stream\.mux\.com\/(\w+)/
+// Match Mux m3u8 URLs without the extension so users can use hls.js with Mux by adding the `.m3u8` extension. https://regexr.com/7um5f
+export const MATCH_URL_MUX = /stream\.mux\.com\/(?!\w+\.m3u8)(\w+)/
 export const MATCH_URL_FACEBOOK = /^https?:\/\/(www\.)?facebook\.com.*\/(video(s)?|watch|story)(\.php?|\/).+$/
 export const MATCH_URL_FACEBOOK_WATCH = /^https?:\/\/fb\.watch\/.+$/
 export const MATCH_URL_STREAMABLE = /streamable\.com\/([a-z0-9]+)$/


### PR DESCRIPTION
fix https://github.com/cookpete/react-player/issues/1763

adds a regex change for player selection

https://stream.mux.com/maVbJv2GSYNRgS02kPXOOGdJMWGU1mkA019ZUjYE7VU7k -> Mux player
https://stream.mux.com/maVbJv2GSYNRgS02kPXOOGdJMWGU1mkA019ZUjYE7VU7k.m3u8 -> hls.js