### PR TITLE
Move exports.key.default to last position

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "default": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./lazy": {
-      "default": "./dist/lazy/index.js",
-      "types": "./dist/lazy/index.d.ts"
+      "types": "./dist/lazy/index.d.ts",
+      "default": "./dist/lazy/index.js"
     },
     "./*": {
-      "default": "./dist/*.js",
-      "types": "./dist/*.d.ts"
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
Addresses https://github.com/cookpete/react-player/issues/1613#issuecomment-2067993523

---

Comment content copied here:

Ah, seems like this `'react-player/file'` import fails with a `Default condition should be last one` error message on compile time (Next.js) though 😬

```
Module not found: Default condition should be last one
  5 | // eslint-disable-next-line import/no-unresolved -- eslint-plugin-import doesn't understand `exports` in package.json yet https://github.com/import-js/eslint-plugin-import/issues/1810
> 6 | import ReactPlayer from 'react-player/file';
    | ^
  7 |
  8 | // ```
  9 |

https://nextjs.org/docs/messages/module-not-found
```

So maybe [the `"exports"` config in `package.json`](https://unpkg.com/browse/react-player@3.0.0-canary.3/package.json) is misconfigured...

Eg. an example PR fixing such an error:

- https://github.com/firebase/firebase-js-sdk/pull/7007