### PR TITLE
add an option to load libraries from custom domain

### DIFF
--- a/src/players/FilePlayer.js
+++ b/src/players/FilePlayer.js
@@ -160,7 +160,7 @@ export default class FilePlayer extends Component {
   }
 
   load (url) {
-    const { hlsVersion, hlsOptions, dashVersion, flvVersion } = this.props.config
+    const { hlsSdkUrl, hlsVersion, hlsOptions, dashVersion, dashSdkUrl, flvVersion, flvSdkUrl } = this.props.config
     if (this.hls) {
       this.hls.destroy()
     }
@@ -168,7 +168,7 @@ export default class FilePlayer extends Component {
       this.dash.reset()
     }
     if (this.shouldUseHLS(url)) {
-      getSDK(HLS_SDK_URL.replace('VERSION', hlsVersion), HLS_GLOBAL).then(Hls => {
+      getSDK(hlsSdkUrl || HLS_SDK_URL.replace('VERSION', hlsVersion), HLS_GLOBAL).then(Hls => {
         this.hls = new Hls(hlsOptions)
         this.hls.on(Hls.Events.MANIFEST_PARSED, () => {
           this.props.onReady()
@@ -187,7 +187,7 @@ export default class FilePlayer extends Component {
       })
     }
     if (this.shouldUseDASH(url)) {
-      getSDK(DASH_SDK_URL.replace('VERSION', dashVersion), DASH_GLOBAL).then(dashjs => {
+      getSDK(dashSdkUrl || DASH_SDK_URL.replace('VERSION', dashVersion), DASH_GLOBAL).then(dashjs => {
         this.dash = dashjs.MediaPlayer().create()
         this.dash.initialize(this.player, url, this.props.playing)
         this.dash.on('error', this.props.onError)
@@ -200,7 +200,7 @@ export default class FilePlayer extends Component {
       })
     }
     if (this.shouldUseFLV(url)) {
-      getSDK(FLV_SDK_URL.replace('VERSION', flvVersion), FLV_GLOBAL).then(flvjs => {
+      getSDK(flvSdkUrl || FLV_SDK_URL.replace('VERSION', flvVersion), FLV_GLOBAL).then(flvjs => {
         this.flv = flvjs.createPlayer({ type: 'flv', url })
         this.flv.attachMediaElement(this.player)
         this.flv.on(flvjs.Events.ERROR, (e, data) => {

--- a/src/props.js
+++ b/src/props.js
@@ -66,8 +66,11 @@ export const propTypes = {
       forceFLV: bool,
       hlsOptions: object,
       hlsVersion: string,
+      hlsSdkUrl: string,
       dashVersion: string,
-      flvVersion: string
+      dashSdkUrl: string,
+      flvVersion: string,
+      flvSdkUrl: string
     }),
     wistia: shape({
       options: object,
@@ -103,7 +106,7 @@ export const propTypes = {
   onDisablePIP: func
 }
 
-const noop = () => {}
+const noop = () => { }
 
 export const defaultProps = {
   playing: false,

--- a/types/file.d.ts
+++ b/types/file.d.ts
@@ -20,8 +20,11 @@ export interface FileConfig {
   forceFLV?: boolean
   hlsOptions?: Record<string, any>
   hlsVersion?: string
+  hlsSdkUrl?: string
   dashVersion?: string
+  dashSdkUrl?: string
   flvVersion?: string
+  flvSdkUrl?: string
 }
 
 export interface FilePlayerProps extends BaseReactPlayerProps {


### PR DESCRIPTION
Hi, this Pr is an attempts to provide new configuration options to allow to load hls, dash and flv library from custom domain.
I am required to do so to use that library in a controller environment where specific domains need to be allowed to fetch content.