### PR TITLE
Fix #1460: Remove memorization of getConfig to prevent stale config renders

### DIFF
--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -119,7 +119,7 @@ export const createReactPlayer = (players, fallback) => {
       return null
     })
 
-    getConfig = memoize((url, key) => {
+    getConfig = (url, key) => {
       const { config } = this.props
       return merge.all([
         defaultProps.config,
@@ -127,7 +127,7 @@ export const createReactPlayer = (players, fallback) => {
         config,
         config[key] || {}
       ])
-    })
+    }
 
     getAttributes = memoize(url => {
       return omit(this.props, SUPPORTED_PROPS)


### PR DESCRIPTION
This PR addresses #1460 by removing the memorization of `getConfig` in `src/ReactPlayer.js`. This change prevents stale config renders by ensuring that the latest configuration is always used.

Changes:
- Updates `getConfig` to be a non-memoized function.