### PR TITLE
feat: allow the className prop for ReactPlayer

### DIFF
--- a/src/ReactPlayer.js
+++ b/src/ReactPlayer.js
@@ -167,12 +167,12 @@ export const createReactPlayer = (players, fallback) => {
     }
 
     render () {
-      const { url, style, width, height, fallback, wrapper: Wrapper } = this.props
+      const { url, style, width, height, fallback, wrapper: Wrapper, className } = this.props
       const { showPreview } = this.state
       const attributes = this.getAttributes(url)
       const wrapperRef = typeof Wrapper === 'string' ? this.references.wrapper : undefined
       return (
-        <Wrapper ref={wrapperRef} style={{ ...style, width, height }} {...attributes}>
+        <Wrapper ref={wrapperRef} style={{ ...style, width, height }} className={className} {...attributes}>
           <UniversalSuspense fallback={fallback}>
             {showPreview
               ? this.renderPreview(url)


### PR DESCRIPTION
## description

In some CSS libraries, there are cases where styles are inherited via the className. When disallowing such className, you may need to develop that specific part of the project using a different pattern than the one you previously used. Therefore, I added code to allow the className prop.

## Example of [Panda CSS](https://panda-css.com/)

### AS-IS

```tsx
<div className={videoPlayerWrapperCss}>
   <ReactPlayer
        style={{ borderRadius: '16px', ... }}
        url={videoUrl}
        playing={true}
        controls={true}
        muted={true}
        width="100%"
        height="100%"
      />
</div>
```

### TO-BE

```tsx
<div className={videoPlayerWrapperCss}>
   <ReactPlayer
        className={css({ borderRadius: '16px', ... })}
        url={videoUrl}
        playing={true}
        controls={true}
        muted={true}
        width="100%"
        height="100%"
      />
</div>
```
