### PR TITLE
fix: add `slot` and other media attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,19 @@ Prop | Description | Default
 ---- | ----------- | -------
 `src` | The url of a video or song to play | `undefined`
 `playing` | Set to `true` or `false` to pause or play the media | `false`
+`preload` | Applies the `preload` attribute where supported | `undefined`
+`playsInline` | Applies the `playsInline` attribute where supported | `false`
+`crossOrigin` | Applies the `crossOrigin` attribute where supported | `undefined`
 `loop` | Set to `true` or `false` to loop the media | `false`
 `controls` | Set to `true` or `false` to display native player controls.<br/>&nbsp; ◦ &nbsp;For Vimeo videos, hiding controls must be enabled by the video owner. | `false`
-`light` | Set to `true` to show just the video thumbnail, which loads the full player on click<br />&nbsp; ◦ &nbsp;Pass in an image URL to override the preview image | `false`
 `volume` | Set the volume of the player, between `0` and `1`<br/>&nbsp; ◦ &nbsp;`null` uses default volume on all players [`#357`](https://github.com/cookpete/react-player/issues/357) | `null`
-`muted` | Mutes the player<br/>&nbsp; ◦ &nbsp;Only works if `volume` is set | `false`
+`muted` | Mutes the player | `false`
 `playbackRate` | Set the playback rate of the player<br />&nbsp; ◦ &nbsp;Only supported by YouTube, Wistia, and file paths | `1`
+`pip` | Set to `true` or `false` to enable or disable [picture-in-picture mode](https://developers.google.com/web/updates/2018/10/watch-video-using-picture-in-picture)<br/>&nbsp; ◦ &nbsp;Only available when playing file URLs in [certain browsers](https://caniuse.com/#feat=picture-in-picture) | `false`
 `width` | Set the width of the player | `320px`
 `height` | Set the height of the player | `180px`
 `style` | Add [inline styles](https://facebook.github.io/react/tips/inline-styles.html) to the root element | `{}`
-`playsInline` | Applies the `playsInline` attribute where supported | `false`
-`pip` | Set to `true` or `false` to enable or disable [picture-in-picture mode](https://developers.google.com/web/updates/2018/10/watch-video-using-picture-in-picture)<br/>&nbsp; ◦ &nbsp;Only available when playing file URLs in [certain browsers](https://caniuse.com/#feat=picture-in-picture) | `false`
+`light` | Set to `true` to show just the video thumbnail, which loads the full player on click<br />&nbsp; ◦ &nbsp;Pass in an image URL to override the preview image | `false`
 `fallback` | Element or component to use as a fallback if you are using lazy loading | `null`
 `wrapper` | Element or component to use as the container element | null
 `playIcon` | Element or component to use as the play icon in light mode

--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -10,7 +10,7 @@ type Player = React.ForwardRefExoticComponent<
 >;
 
 const Player: Player = React.forwardRef((props, ref) => {
-  const { playing, playbackRate, volume, muted, pip } = props;
+  const { playing, pip } = props;
 
   const Player = props.activePlayer;
   const playerRef = useRef<HTMLVideoElement | null>(null);
@@ -26,9 +26,8 @@ const Player: Player = React.forwardRef((props, ref) => {
       playerRef.current.pause();
     }
 
-    playerRef.current.playbackRate = playbackRate ?? 1;
-    playerRef.current.volume = volume ?? 1;
-    playerRef.current.muted = muted ?? false;
+    playerRef.current.playbackRate = props.playbackRate ?? 1;
+    playerRef.current.volume = props.volume ?? 1;
   });
 
   useEffect(() => {
@@ -80,6 +79,7 @@ const Player: Player = React.forwardRef((props, ref) => {
       {...eventProps}
       style={props.style}
       className={props.className}
+      slot={props.slot}
       ref={useCallback(
         (node: HTMLVideoElement) => {
           playerRef.current = node;
@@ -93,10 +93,13 @@ const Player: Player = React.forwardRef((props, ref) => {
         [ref]
       )}
       src={props.src}
+      crossOrigin={props.crossOrigin}
+      preload={props.preload}
       controls={props.controls}
       muted={props.muted}
       autoPlay={props.autoPlay}
       loop={props.loop}
+      playsInline={props.playsInline}
       config={props.config}
       onLoadStart={handleLoadStart}
       onPlay={handlePlay}

--- a/src/ReactPlayer.tsx
+++ b/src/ReactPlayer.tsx
@@ -36,7 +36,7 @@ export const createReactPlayer = (players: PlayerEntry[], playerFallback: Player
   const ReactPlayer: ReactPlayer = React.forwardRef((_props, ref) => {
     const props = merge(defaultProps, _props);
 
-    const { className, src, style, width, height, fallback, wrapper } = props;
+    const { src, slot, className, style, width, height, fallback, wrapper } = props;
     const [showPreview, setShowPreview] = useState(!!props.light);
 
     useEffect(() => {
@@ -81,6 +81,7 @@ export const createReactPlayer = (players: PlayerEntry[], playerFallback: Player
           {...props}
           ref={ref}
           activePlayer={player.player ?? (player as unknown as PlayerEntry['player'])}
+          slot={wrapper ? undefined : slot}
           className={wrapper ? undefined : className}
           style={wrapper
             ? { display: 'block', width: '100%', height: '100%' }
@@ -97,7 +98,7 @@ export const createReactPlayer = (players: PlayerEntry[], playerFallback: Player
       fallback === false ? ForwardChildren : Suspense;
 
     return (
-      <Wrapper className={className} style={{ width, height, ...style }}>
+      <Wrapper slot={slot} className={className} style={{ width, height, ...style }}>
         <UniversalSuspense fallback={fallback}>
           {showPreview ? renderPreview(src) : renderActivePlayer(src)}
         </UniversalSuspense>

--- a/src/props.ts
+++ b/src/props.ts
@@ -1,12 +1,17 @@
 import type { ReactPlayerProps } from './types.js';
 
 export const defaultProps: ReactPlayerProps = {
+  // Falsy values don't need to be defined
+  //
   // native video attrs
-  src: undefined,
-  muted: false,
-  loop: false,
-  controls: false,
-  playsInline: false,
+  // src: undefined,
+  // preload: undefined,
+  // crossOrigin: undefined,
+  // autoPlay: false,
+  // muted: false,
+  // loop: false,
+  // controls: false,
+  // playsInline: false,
   width: '320px',
   height: '180px',
 
@@ -15,10 +20,10 @@ export const defaultProps: ReactPlayerProps = {
   playbackRate: 1,
 
   // custom props
-  playing: false,
-  pip: false,
-  light: false,
-  fallback: null,
+  // playing: false,
+  // pip: false,
+  // light: false,
+  // fallback: null,
   previewTabIndex: 0,
   previewAriaLabel: '',
   oEmbedUrl: 'https://noembed.com/embed?url={url}',

--- a/test/Player.tsx
+++ b/test/Player.tsx
@@ -1,7 +1,7 @@
 import './helpers/server-safe-globals.js';
 import { test } from 'zora';
 import sinon from 'sinon';
-import { ReactTestRenderer, create, act } from 'react-test-renderer';
+import { act } from 'react-test-renderer';
 import React from 'react';
 import Player from '../src/Player';
 import HtmlPlayer from '../src/HtmlPlayer';
@@ -63,10 +63,12 @@ test('video.volume = 0.5', async (t) => {
 });
 
 test('video.muted = true', async (t) => {
-  const videoRef: React.Ref<HTMLVideoElement> = React.createRef();
+  let videoRef: React.Ref<HTMLVideoElement> = React.createRef();
   const wrapper = render(<Player ref={videoRef} src="file.mp4" activePlayer={HtmlPlayer} />);
+  t.equal(videoRef.current?.muted, false);
 
   act(() => {
+    videoRef = React.createRef();
     wrapper.update(<Player ref={videoRef} src="file.mp4" muted activePlayer={HtmlPlayer} />);
   });
   await Promise.resolve();
@@ -75,10 +77,12 @@ test('video.muted = true', async (t) => {
 });
 
 test('video.muted = false', async (t) => {
-  const videoRef: React.Ref<HTMLVideoElement> = React.createRef();
+  let videoRef: React.Ref<HTMLVideoElement> = React.createRef();
   const wrapper = render(<Player ref={videoRef} src="file.mp4" muted activePlayer={HtmlPlayer} />);
+  t.equal(videoRef.current?.muted, true);
 
   act(() => {
+    videoRef = React.createRef();
     wrapper.update(<Player ref={videoRef} src="file.mp4" activePlayer={HtmlPlayer} />);
   });
   await Promise.resolve();

--- a/test/helpers/helpers.tsx
+++ b/test/helpers/helpers.tsx
@@ -10,7 +10,8 @@ export function render(comp: React.ReactElement): ReactTestRenderer {
       createNodeMock: (element) => {
         if (element.type === 'video') {
           const video = document.createElement('video');
-          video.setAttribute('src', element.props.src);
+          video.src = element.props.src;
+          video.muted = element.props.muted;
           return video;
         }
       },

--- a/test/helpers/server-safe-globals.js
+++ b/test/helpers/server-safe-globals.js
@@ -15,10 +15,14 @@ class Element extends EventTarget {
 }
 
 class HTMLVideoElement extends Element {
+  #attrs = {
+    muted: false,
+    src: '',
+  };
+
   constructor() {
     super();
     this.paused = true;
-    this.muted = false;
     this.volume = 1;
     this.currentTime = 0;
     this.duration = NaN;
@@ -27,9 +31,31 @@ class HTMLVideoElement extends Element {
 
   setAttribute(name, value) {
     if (name === 'src') {
-      this.src = value;
+      this.#attrs.src = value;
       this.load();
+    } else {
+      this.#attrs[name] = value;
     }
+  }
+
+  getAttribute(name) {
+    return this.#attrs[name];
+  }
+
+  get src() {
+    return this.getAttribute('src');
+  }
+
+  set src(value) {
+    this.setAttribute('src', value);
+  }
+
+  get muted() {
+    return this.getAttribute('muted');
+  }
+
+  set muted(value) {
+    this.setAttribute('muted', !!value);
   }
 
   async load() {


### PR DESCRIPTION
This adds the `slot` attribute, `preload` and `crossOrigin`