### PR TITLE
Fix: prevent infinite recursion in deepmerge by extracting children prop

### DIFF
--- a/src/ReactPlayer.tsx
+++ b/src/ReactPlayer.tsx
@@ -33,7 +33,7 @@ export const createReactPlayer = (players: PlayerEntry[], playerFallback: Player
     return null;
   };
 
-  const ReactPlayer: ReactPlayer = React.forwardRef((_props, ref) => {
+  const ReactPlayer: ReactPlayer = React.forwardRef(({ children, ..._props } , ref) => {
     const props = merge(defaultProps, _props);
 
     const { src, slot, className, style, width, height, fallback, wrapper } = props;
@@ -87,6 +87,7 @@ export const createReactPlayer = (players: PlayerEntry[], playerFallback: Player
             ? { display: 'block', width: '100%', height: '100%' }
             : { display: 'block', width, height, ...style }}
           config={config}
+          children={children}
         />
       );
     };

--- a/src/ReactPlayer.tsx
+++ b/src/ReactPlayer.tsx
@@ -87,8 +87,7 @@ export const createReactPlayer = (players: PlayerEntry[], playerFallback: Player
             ? { display: 'block', width: '100%', height: '100%' }
             : { display: 'block', width, height, ...style }}
           config={config}
-          children={children}
-        />
+        >{children}</Player>
       );
     };
 


### PR DESCRIPTION
- Updated ReactPlayer to destructure and exclude children from props before merging with defaultProps.
- This prevents deepmerge from causing infinite recursion when children are present.
- Children are now explicitly passed to the underlying player component, enabling custom content without recursion issues.