### PR TITLE
docs: Add a Youtube playlist example

### DIFF
--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -449,6 +449,7 @@ const App = () => {
               <td>
                 {renderLoadButton('https://www.youtube.com/watch?v=oUFJJNQGwhk', 'Test A')}
                 {renderLoadButton('https://www.youtube.com/watch?v=jNgP6d9HraI', 'Test B')}
+                {renderLoadButton('https://www.youtube.com/playlist?list=PLRfhDHeBTBJ7MU5DX4P_oBIRN457ah9lA', 'Playlist')}
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
When https://github.com/muxinc/media-elements/pull/134 will be merged & released, it would be nice to have a playlist example. Since original example on https://github.com/cookpete/react-player/blob/v2.16.0/examples/react/src/App.js#L276 is empty now (because of copyright claims), let's put an example with some videos