### PR TITLE
Fix: Add share URLs to TikTok pattern matching

### DIFF
--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -12,7 +12,7 @@ export const MATCH_URL_WISTIA =
   /(?:wistia\.(?:com|net)|wi\.st)\/(?:medias|embed)\/(?:iframe\/)?([^?]+)/;
 export const MATCH_URL_SPOTIFY = /open\.spotify\.com\/(\w+)\/(\w+)/i;
 export const MATCH_URL_TWITCH = /(?:www\.|go\.)?twitch\.tv\/([a-zA-Z0-9_]+|(videos?\/|\?video=)\d+)($|\?)/;
-export const MATCH_URL_TIKTOK = /tiktok\.com\/(?:@[^/]+\/video\/)?(\d+)(?:\/([\w-]+))?/;
+export const MATCH_URL_TIKTOK = /tiktok\.com\/(?:(?:@[\w\.]+)|share)\/video\/(\d+)(?:\/([\w-]+))?/;
 
 const canPlayFile = (url: string, test: (u: string) => boolean) => {
   if (Array.isArray(url)) {

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -12,7 +12,7 @@ export const MATCH_URL_WISTIA =
   /(?:wistia\.(?:com|net)|wi\.st)\/(?:medias|embed)\/(?:iframe\/)?([^?]+)/;
 export const MATCH_URL_SPOTIFY = /open\.spotify\.com\/(\w+)\/(\w+)/i;
 export const MATCH_URL_TWITCH = /(?:www\.|go\.)?twitch\.tv\/([a-zA-Z0-9_]+|(videos?\/|\?video=)\d+)($|\?)/;
-export const MATCH_URL_TIKTOK = /tiktok\.com\/(?:(?:@[\w\.]+)|share)\/video\/(\d+)(?:\/([\w-]+))?/;
+export const MATCH_URL_TIKTOK = /tiktok\.com\/(?:player\/v1\/|share\/video\/|@[^/]+\/video\/)([0-9]+)/;
 
 const canPlayFile = (url: string, test: (u: string) => boolean) => {
   if (Array.isArray(url)) {


### PR DESCRIPTION
This is a PR which should depend upon https://github.com/muxinc/media-elements/pull/150 merging.

If there are any updates to the regex in that PR then this should also be updated.

---

TikTok supports two versions of URL's:

https://www.tiktok.com/@_luwes/video/7527476667770522893
and
https://www.tiktok.com/share/video/7527476667770522893

The second format redirects to the first format, but is still accessible as an embed src. This is useful since TikTok users may change usernames.